### PR TITLE
Filepaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,18 +175,21 @@ below.
 
 #### General
 
-| Option              | Description                                                                              | Default         |
-| ------------------- | ---------------------------------------------------------------------------------------- | --------------- |
-| Autotrim            | Trim extra whitespace from the ends of the input                                         | `true`          |
-| CompletionsOffset   | The left margin offset of the completion list                                            | `0`             |
-| CompletionsPosition | The position of the completion list relative to the input                                | `PositionBelow` |
-| CompletionRows      | The number of rows to show in the completion list before scrolling                       | `5`             |
-| HistoryFilePath     | The path to a `.json` file to store the command history for persistence between sessions (configure via `WithHistoryFilePath` / `SetHistoryFilePath` — no public field) | -               |
-| HistoryLimit        | The maximum number of history entries to store and save                                  | `100`           |
-| IndentCompletions   | Indent the completion list to match the current input length                             | `true`          |
-| ShowBorderScroll    | Show different border colors around the completion list to indicate scrolling            | `false`         |
-| ShowScrollbar       | Show a vertical scrollbar to indicate scrolling                                          | `false`         |
-| ShowDescriptions    | Render the description column next to each completion name                               | `true`          |
+| Option                    | Description                                                                              | Default         |
+| ------------------------- | ---------------------------------------------------------------------------------------- | --------------- |
+| Autotrim                  | Trim extra whitespace from the ends of the input                                         | `true`          |
+| CompletionsOffset         | The left margin offset of the completion list                                            | `0`             |
+| CompletionsPosition       | The position of the completion list relative to the input                                | `PositionBelow` |
+| CompletionRows            | The number of rows to show in the completion list before scrolling                       | `5`             |
+| FilesystemCompletions     | Enable live filesystem completion and validity colouring for file/dir argument values    | `false`         |
+| FilesystemCompletionLimit | Maximum filesystem candidates surfaced per keystroke                                     | `200`           |
+| HiddenFiles               | Surface dotfiles even when the typed prefix does not start with `.`                      | `false`         |
+| HistoryFilePath           | The path to a `.json` file to store the command history for persistence between sessions (configure via `WithHistoryFilePath` / `SetHistoryFilePath` — no public field) | -               |
+| HistoryLimit              | The maximum number of history entries to store and save                                  | `100`           |
+| IndentCompletions         | Indent the completion list to match the current input length                             | `true`          |
+| ShowBorderScroll          | Show different border colors around the completion list to indicate scrolling            | `false`         |
+| ShowScrollbar             | Show a vertical scrollbar to indicate scrolling                                          | `false`         |
+| ShowDescriptions          | Render the description column next to each completion name                               | `true`          |
 
 #### Icons
 
@@ -208,19 +211,22 @@ s.Completion.Match = lipgloss.NewStyle().Bold(true)
 bc.SetStyles(s)
 ```
 
-| Field                    | Description                                          | Default           |
-| ------------------------ | ---------------------------------------------------- | ----------------- |
-| Input.Valid              | Style for valid user input                           | (green)           |
-| Input.Invalid            | Style for invalid user input                         | (muted text)      |
-| Completion.Match         | Style for the matched prefix in completions          | (bold pink)       |
-| Completion.SelectedRow   | Style for the selected completion row                | (bold, highlight) |
-| Completion.Row           | Style for odd completion rows                        | (subtle bg)       |
-| Completion.AltRow        | Style for even completion rows                       | (alt subtle bg)   |
-| Completion.Border        | Style for the completions border                     | (rounded border)  |
-| Completion.Description   | Style for completion descriptions                    | (muted)           |
-| Completion.Icon          | Style for type indicator icons                       | (pink)            |
-| Scrollbar.Thumb          | Style for the scrollbar thumb                        | (pink)            |
-| Scrollbar.Track          | Style for the scrollbar track                        | (border color)    |
+| Field                    | Description                                                  | Default           |
+| ------------------------ | ------------------------------------------------------------ | ----------------- |
+| Input.Valid              | Style for valid user input                                   | (green)           |
+| Input.Invalid            | Style for invalid user input                                 | (muted text)      |
+| Input.PathValid          | Overlay on the typed path value when it resolves correctly   | (green)           |
+| Input.PathPartial        | Overlay on the typed path value while mid-navigation         | (underline)       |
+| Input.PathInvalid        | Overlay on the typed path value when it cannot resolve       | (red)             |
+| Completion.Match         | Style for the matched prefix in completions                  | (bold pink)       |
+| Completion.SelectedRow   | Style for the selected completion row                        | (bold, highlight) |
+| Completion.Row           | Style for odd completion rows                                | (subtle bg)       |
+| Completion.AltRow        | Style for even completion rows                               | (alt subtle bg)   |
+| Completion.Border        | Style for the completions border                             | (rounded border)  |
+| Completion.Description   | Style for completion descriptions                            | (muted)           |
+| Completion.Icon          | Style for type indicator icons                               | (pink)            |
+| Scrollbar.Thumb          | Style for the scrollbar thumb                                | (pink)            |
+| Scrollbar.Track          | Style for the scrollbar track                                | (border color)    |
 
 #### Key Bindings
 
@@ -260,17 +266,51 @@ bc.SetKeyMap(k)
 
 ### Filesystem Argument Validation
 
-`FileArgument`, `DirArgument`, and `FileDirArgument` validate the value against the real filesystem using `os.Stat`. Paths are resolved relative to the process's working directory. Quoted strings are unquoted before the stat check, so `cat "my file.txt"` works as long as the file actually exists. A configurable working-directory / filesystem abstraction is on the roadmap.
+`FileArgument`, `DirArgument`, and `FileDirArgument` validate the value against the real filesystem using `os.Stat`. The value is run through a shared resolver first: a leading `~` (or `~/`) is expanded against `$HOME`; relative paths are joined with the process's working directory. Unclosed quotes (`"foo` with no closing `"`) surface as `UnclosedQuote`, matching how `StringArgument` already validates. Single-quoted values suppress tilde expansion, mirroring shell semantics. A configurable working-directory / filesystem abstraction is on the roadmap.
+
+### Filesystem Completions
+
+`WithFilesystemCompletions(true)` enables live filesystem completion and per-token validity colouring for any `FileArgument`, `DirArgument`, or `FileDirArgument` value the user is editing. Default is off; the feature is opt-in.
+
+When active, the completion list is replaced wholesale with matching entries from the relevant parent directory — directories first (with a trailing `/` for navigation), then files, sorted case-fold. `Tab` cycles forward, `Shift+Tab` cycles backward, `Right` (or typing) accepts. Tab-accepting a directory adds the trailing slash so the next keystroke drills into it.
+
+The typed value gets a coloured overlay reflecting its filesystem state:
+
+- **green** — resolves to an entry of the expected kind
+- **underlined white** — strict prefix of one or more existing entries (mid-navigation)
+- **red** — does not resolve, or resolves to the wrong kind
+
+The invariant the feature guarantees, *when the overlay is shown*: green ⇔ Enter accepts. Classifier and `validatePath` resolve and stat by the same rules. The overlay can be suppressed by the limitations listed below (overflow, cycling); in those cases a green-resolving path is still accepted on Enter, but the colour is absent.
+
+**Quoting.** Values are quote-aware: typing `cat "~/My Doc<Tab>"` completes inside the quotes. If the user types `cat ~/M<Tab>` and the matched basename contains a space, the inserted token is auto-quoted with double quotes. Equals-form flag values (`--path=~/foo`) preserve the `--path=` prefix; only the value portion is coloured.
+
+**Tilde policy.** `~` and `~/` expand outside quotes and inside `"..."`; not inside `'...'`. This deviates pragmatically from strict POSIX (which would not expand inside `"..."`) — users who quote because of spaces still expect `~` to work.
+
+**Modal context.** While editing a path value, the completion list shows only filesystem entries. Flag suggestions are intentionally hidden in this mode — to surface them, move the cursor out of the value position (type a space or backspace out).
+
+**Caching.** Directory reads are cached for 2 seconds across up to 64 distinct parent directories. The first keystroke into a new directory pays one `os.ReadDir`; subsequent keystrokes avoid the repeat read but still scan the cached entries and may stat a bounded number of symlinks. Permission errors and missing directories are cached too, so a bad path doesn't trigger a retry storm.
+
+**Documented limitations.**
+
+- **Permission denied** silently falls back to the argument hint row. The whole-input style still signals the error via the validation system, but no specific "permission denied" row appears in the completion list.
+- **Devices, sockets, pipes** never appear as completion candidates regardless of `ArgumentType`. They still validate per kind if typed directly (a `FileArgument` accepts `/dev/null` because `!IsDir()` matches).
+- **Filenames containing literal quote characters** (`"` or `'`) are inserted verbatim and cannot be re-parsed by the tokenizer as a single token. Vanishingly rare in practice.
+- **Multi-token unquoted paths** like `cat ~/My Doc` are not recovered: once a space is typed, the tokenizer has split the path. Open a quote first (`cat "~/My Doc`) or rely on auto-quote (`cat ~/M<Tab>` picks the spaced basename).
+- **Cold huge directories** (10k+ entries) produce a one-time stall on the first read. Subsequent keystrokes within the TTL window avoid the repeat read.
+- **Case sensitivity** is a heuristic: case-sensitive on Linux, case-insensitive on macOS and Windows. APFS case-sensitive volumes on macOS will surface completions the filesystem won't actually open.
+- **Unicode normalisation** on macOS HFS+: the filesystem stores filenames in NFD form, but users typically type in NFC. A typed `~/Documents/résumé.pdf` (NFC) won't match the on-disk `résumé.pdf` (NFD) and the path will silently colour red. Not fixed in v1; would require pulling in `golang.org/x/text/unicode/norm`.
+- **Inputs wider than the terminal** lose the validity overlay (the underlying textinput's scroll window can't be reliably indexed into for offset math).
+- **During Tab cycling** the overlay is bypassed — the frozen `pathState` offsets refer to the pre-cycling input, so styling the cycled preview would mis-align. The overlay returns after the user accepts (or cancels) cycling.
 
 ## Roadmap
 
 - [x] Update to bubbletea v2
 - [x] Support PowerShell style flags
 - [ ] Support PowerShell aliases for flags i.e. `-v` for `-Verbose`
-- [ ] Autocomplete for filepaths
-  - [ ] Underlined white if part of a valid path
-  - [ ] Green if full valid path
-  - [ ] Red if invalid path
+- [x] Autocomplete for filepaths
+  - [x] Underlined white if part of a valid path
+  - [x] Green if full valid path
+  - [x] Red if invalid path
 - [ ] Option to have flags disable other flags if they're mutually exclusive
 - [x] Improved documentation comments for public functions and structs
 - [x] Wider range of tests for more critical functions, for improved maintainability

--- a/README.md
+++ b/README.md
@@ -272,7 +272,7 @@ bc.SetKeyMap(k)
 
 `WithFilesystemCompletions(true)` enables live filesystem completion and per-token validity colouring for any `FileArgument`, `DirArgument`, or `FileDirArgument` value the user is editing. Default is off; the feature is opt-in.
 
-When active, the completion list is replaced wholesale with matching entries from the relevant parent directory — directories first (with a trailing `/` for navigation), then files, sorted case-fold. `Tab` cycles forward, `Shift+Tab` cycles backward, `Right` (or typing) accepts. Tab-accepting a directory adds the trailing slash so the next keystroke drills into it.
+When active, the completion list is replaced wholesale with matching entries from the relevant parent directory — directories first (with a trailing `/` for navigation), then files, sorted case-fold. `Tab` cycles forward, `Shift+Tab` cycles backward, `Right` (or typing) accepts. Tab-accepting a directory adds the trailing slash so the next keystroke drills into it. When there's only **one** candidate, `Tab` auto-accepts immediately and exits cycling — so a second `Tab` lists the children of the just-accepted directory, matching shell tab-completion behaviour.
 
 The typed value gets a coloured overlay reflecting its filesystem state:
 

--- a/README.md
+++ b/README.md
@@ -300,7 +300,7 @@ The invariant the feature guarantees, *when the overlay is shown*: green ⇔ Ent
 - **Case sensitivity** is a heuristic: case-sensitive on Linux, case-insensitive on macOS and Windows. APFS case-sensitive volumes on macOS will surface completions the filesystem won't actually open.
 - **Unicode normalisation** on macOS HFS+: the filesystem stores filenames in NFD form, but users typically type in NFC. A typed `~/Documents/résumé.pdf` (NFC) won't match the on-disk `résumé.pdf` (NFD) and the path will silently colour red. Not fixed in v1; would require pulling in `golang.org/x/text/unicode/norm`.
 - **Inputs wider than the terminal** lose the validity overlay (the underlying textinput's scroll window can't be reliably indexed into for offset math).
-- **During Tab cycling** the overlay is bypassed — the frozen `pathState` offsets refer to the pre-cycling input, so styling the cycled preview would mis-align. The overlay returns after the user accepts (or cancels) cycling.
+- **During Tab cycling**, the overlay refreshes per-cycle and tracks the cycled candidate's validity. Directory candidates (no trailing space) show their classification per cycle — `pathPartial` (mid-navigation) under `FileArgument`, `pathValid` under `DirArgument`. File candidates carry a trailing space (bash-style "token done"), which makes `activeFileArgument` inactive for that preview — files cycle without an overlay colour. The cycled file values are all real files by construction (they survived the candidate kind filter), so the missing colour signals nothing.
 
 ## Roadmap
 

--- a/bubblecomplete.go
+++ b/bubblecomplete.go
@@ -58,13 +58,20 @@ func (m Model) Update(msg tea.Msg) (Model, tea.Cmd) {
 	// If the input has changed, update the completions and validate the input
 	if m.input.Value() != "" && m.input.Value() != m.lastInput && m.completionHolder == "" && !m.showAll {
 		m.lastInput = m.input.Value()
+		m.recomputePathState()
 		m.completions, m.matchPrefix = m.getCompletions()
 		m.validationErr = m.validateInput()
 		m.applyInputValidationStyle()
-	} else if m.input.Value() == "" && m.validationErr != nil {
-		m.validationErr = nil
+	} else if m.input.Value() == "" && m.lastInput != "" {
+		// Input cleared. Always reset lastInput and pathState so a stale
+		// path-completion overlay can't survive a delete-all; clear the
+		// validation style only when there's an error to clear.
 		m.lastInput = ""
-		m.applyInputValidationStyle()
+		m.pathState = pathState{}
+		if m.validationErr != nil {
+			m.validationErr = nil
+			m.applyInputValidationStyle()
+		}
 	}
 
 	// If not loaded, start the blinking cursor
@@ -106,6 +113,7 @@ func (m Model) resetModel() Model {
 	m.matchPrefix = ""
 	m.lastInput = ""
 	m.validationErr = nil
+	m.pathState = pathState{}
 	m = m.clearTransientCompletionState()
 	m.applyInputValidationStyle()
 	return m

--- a/bubblecomplete.go
+++ b/bubblecomplete.go
@@ -263,6 +263,14 @@ func (m Model) keyTab(forward bool) (Model, tea.Cmd) {
 	if m.completionIndex == -1 {
 		m.input.SetValue(m.completionHolder)
 		m.completionHolder = ""
+		// Refresh pathState against the restored value. The input-changed
+		// branch later in Update won't help here: the restored value
+		// equals m.lastInput (set before cycling began), so the branch
+		// skips. Without this refresh, pathState would still belong to
+		// the last-cycled preview value — stale offsets, wrong validity,
+		// or (after a cycled file's trailing space made it inactive) no
+		// overlay at all on a path that should now show partial/invalid.
+		m.recomputePathState()
 		return m, nil
 	}
 
@@ -285,20 +293,31 @@ func (m Model) keyTab(forward bool) (Model, tea.Cmd) {
 	m.input.SetValue(pretext + m.completions[m.completionIndex].getAutocomplete())
 	m.input.CursorEnd()
 
-	// Single-match acceptance: when there's exactly one completion to choose
-	// from, treat Tab as a final accept rather than entering cycling state.
-	// Clearing completionHolder here means the input-changed branch later
-	// in this same Update call (after textinput.Update) will recompute
-	// against the new input value — populating fresh completions and
-	// pathState for the just-accepted text. The next Tab then cycles
-	// among those new candidates, which for a directory match enables the
-	// shell-style drill-down: Tab on "cd Do" with a unique "Documents/"
-	// candidate accepts it AND repopulates with Documents/'s children, so
-	// the second Tab descends one level.
 	if len(m.completions) == 1 {
+		// Single-match acceptance: treat Tab as a final accept rather than
+		// entering cycling state. Clearing completionHolder here means the
+		// input-changed branch later in this same Update call (after
+		// textinput.Update) will recompute against the new input value —
+		// populating fresh completions and pathState for the just-accepted
+		// text. The next Tab then cycles among those new candidates, which
+		// for a directory match enables the shell-style drill-down: Tab
+		// on "cd Do" with a unique "Documents/" candidate accepts it AND
+		// repopulates with Documents/'s children, so the second Tab
+		// descends one level.
 		m.completionHolder = ""
 		m.completionIndex = -1
 		m.showAll = false
+	} else {
+		// Multi-match cycling: completionHolder stays set so the user can
+		// continue cycling or revert to the original via Shift+Tab past
+		// the start. The input-changed branch is therefore skipped on the
+		// next Update tick. Refresh pathState here so the render overlay
+		// reflects the *cycled* value's validity — without this, the
+		// frozen offsets and validity would mis-style the preview (the
+		// old cycling-bypass behaviour in renderedInput). m.completions
+		// is intentionally NOT recomputed: the cycling list is the
+		// candidates we entered cycling with.
+		m.recomputePathState()
 	}
 	return m, nil
 }

--- a/bubblecomplete.go
+++ b/bubblecomplete.go
@@ -284,6 +284,22 @@ func (m Model) keyTab(forward bool) (Model, tea.Cmd) {
 	// Update the input with the current completion
 	m.input.SetValue(pretext + m.completions[m.completionIndex].getAutocomplete())
 	m.input.CursorEnd()
+
+	// Single-match acceptance: when there's exactly one completion to choose
+	// from, treat Tab as a final accept rather than entering cycling state.
+	// Clearing completionHolder here means the input-changed branch later
+	// in this same Update call (after textinput.Update) will recompute
+	// against the new input value — populating fresh completions and
+	// pathState for the just-accepted text. The next Tab then cycles
+	// among those new candidates, which for a directory match enables the
+	// shell-style drill-down: Tab on "cd Do" with a unique "Documents/"
+	// candidate accepts it AND repopulates with Documents/'s children, so
+	// the second Tab descends one level.
+	if len(m.completions) == 1 {
+		m.completionHolder = ""
+		m.completionIndex = -1
+		m.showAll = false
+	}
 	return m, nil
 }
 

--- a/completions.go
+++ b/completions.go
@@ -491,7 +491,23 @@ func splitPositionArgsAndFlags(argParts []string, command *Command, globalFlags 
 // matching flag — validation enforces that only the last char in a combined
 // group may be non-bool (and therefore value-taking), so attributing the
 // token to that flag is consistent with how the command would actually parse.
+//
+// PsFlag and LongFlag matches (exact-token OR equals-form, since
+// containsLongFlag / containsPowerShellFlag also recognise "--flag=value"
+// and "-Path=value") are checked BEFORE the combined-short-flag heuristic.
+// A multi-letter PsFlag like "-Path" is indistinguishable token-shape-wise
+// from a combined short flag "-Path" (the body is all ASCII letters,
+// length > 1), so the combined-short-flag branch must not preempt a real
+// PsFlag match.
 func findMatchingFlag(arg string, effectiveFlags []*Flag) *Flag {
+	for _, f := range effectiveFlags {
+		if f.PsFlag != "" && containsPowerShellFlag(arg, f.PsFlag) {
+			return f
+		}
+		if f.LongFlag != "" && containsLongFlag(arg, f.LongFlag) {
+			return f
+		}
+	}
 	if isCombinedShortFlag(arg) {
 		lastChar := "-" + arg[len(arg)-1:]
 		for _, f := range effectiveFlags {

--- a/completions.go
+++ b/completions.go
@@ -62,7 +62,6 @@ func uniqueCompletions(completions *[]completion) {
 // getCompletions gets completions for the input based on the available commands
 func getCompletions(input string, commands []*Command) ([]completion, string) {
 	var completions []completion
-	var globalFlags []*Flag
 
 	// If the input is empty, return nothing
 	if strings.TrimSpace(input) == "" {
@@ -87,29 +86,7 @@ func getCompletions(input string, commands []*Command) ([]completion, string) {
 	}
 
 	// Otherwise we have at least one command entered so find the final valid command entered
-	var finalCommand *Command
-	commandDepth := 0
-	for _, enteredInput := range parts {
-		for _, c := range commands {
-			// If the command is found in the available commands and we've finished typing then use it
-			if c.Command == enteredInput && inputContainsCompletedToken(input, c.Command) {
-				finalCommand = c
-				commands = c.SubCommands
-				commandDepth++
-				// Carry all persistent flags forward as effective flags on
-				// subcommands. Downstream completion paths dedupe via
-				// containsFlag, so we must not pre-filter here — value-
-				// detection needs the persistent flag in scope even when
-				// the user is actively entering it.
-				for _, flag := range c.Flags {
-					if flag.Persistent {
-						globalFlags = append(globalFlags, flag)
-					}
-				}
-				break
-			}
-		}
-	}
+	finalCommand, commandDepth, globalFlags := walkToFinalCommand(input, parts, commands)
 
 	// If we haven't found any command, it must be invalid input so return nothing
 	if finalCommand == nil {
@@ -521,6 +498,34 @@ func findMatchingFlag(arg string, effectiveFlags []*Flag) *Flag {
 func isCombinedShortFlag(arg string) bool {
 	body, ok := shortFlagBody(arg)
 	return ok && len(body) > 1
+}
+
+// walkToFinalCommand walks the parsed input parts down the command tree and
+// returns the deepest matched command, how many parts were consumed by command
+// words, and the persistent flags accumulated from ancestor commands. Returns
+// finalCmd == nil when no command word matched.
+//
+// Persistent flags propagate to every subcommand. Downstream completion paths
+// dedupe via [containsFlag], so we must not pre-filter here — value-detection
+// needs the persistent flag in scope even when the user is actively entering
+// it.
+func walkToFinalCommand(input string, parts []string, commands []*Command) (finalCmd *Command, commandDepth int, globalFlags []*Flag) {
+	for _, enteredInput := range parts {
+		for _, c := range commands {
+			if c.Command == enteredInput && inputContainsCompletedToken(input, c.Command) {
+				finalCmd = c
+				commands = c.SubCommands
+				commandDepth++
+				for _, flag := range c.Flags {
+					if flag.Persistent {
+						globalFlags = append(globalFlags, flag)
+					}
+				}
+				break
+			}
+		}
+	}
+	return finalCmd, commandDepth, globalFlags
 }
 
 // inputContainsCompletedToken returns true if input contains an unquoted token

--- a/completions.go
+++ b/completions.go
@@ -10,6 +10,22 @@ func (m Model) getCompletions() ([]completion, string) {
 	if m.input.Value() == "" && !m.showAll {
 		return []completion{}, ""
 	}
+
+	// Modal path-completion context: when editing a file/dir argument value
+	// and we have candidates, those replace the entire completion list.
+	// Command and flag rows are intentionally hidden in this mode — the
+	// user is doing filesystem navigation, not flag exploration. To
+	// re-surface them, the user moves the cursor out of the value position.
+	if m.pathState.active && len(m.pathState.candidates) > 0 {
+		out := make([]completion, len(m.pathState.candidates))
+		for i := range m.pathState.candidates {
+			out[i] = m.pathState.candidates[i]
+		}
+		// generateCandidates already produces a deduped, dirs-first
+		// case-fold-alphabetic list; skip sort/unique.
+		return out, m.pathState.base
+	}
+
 	var allCompletions []completion
 	var matchPrefix string
 

--- a/doc.go
+++ b/doc.go
@@ -22,4 +22,9 @@
 // The component validates input continuously; the current error is available
 // via [Model.ValidationError] as a [*ValidationError] that exposes a
 // [ValidationErrorKind] for host-side routing without string matching.
+//
+// Opt in to live filesystem completion and per-token validity colouring for
+// [FileArgument] / [DirArgument] / [FileDirArgument] values via
+// [WithFilesystemCompletions]. See the README for the full behaviour and
+// limitations.
 package bubblecomplete

--- a/example/main.go
+++ b/example/main.go
@@ -39,6 +39,7 @@ func initialModel() tea.Model {
 		bubblecomplete.WithCompletionRows(7),
 		bubblecomplete.WithHistoryLimit(50),
 		bubblecomplete.WithHistoryFilePath(historyFilePath),
+		bubblecomplete.WithFilesystemCompletions(true),
 	)
 	if err != nil {
 		log.Fatal(err)

--- a/fuzz_test.go
+++ b/fuzz_test.go
@@ -123,6 +123,124 @@ func FuzzGetCompletions(f *testing.F) {
 	})
 }
 
+// quoteSeedInputs covers the quote/path inputs worth running under the
+// stripQuotes and resolvePath fuzz targets: bare values, matched and
+// unbalanced quotes, mixed quote chars, tilde forms, separators, and the
+// pathological "two quotes" cases. Standalone from seedInputs because the
+// path-resolver targets exercise narrower-but-still-tricky inputs.
+var quoteSeedInputs = []string{
+	"",
+	"a",
+	`"`,
+	`'`,
+	`""`,
+	`''`,
+	`"a"`,
+	`'a'`,
+	`"a`,
+	`'a`,
+	`"a'`,
+	`'a"`,
+	`"foo"bar"`,
+	"~",
+	"~/",
+	"~/foo",
+	"~/foo/bar",
+	"~user/foo",
+	"./foo",
+	"../foo",
+	"/abs/path",
+	"/",
+	"foo",
+	"日本",
+	"\x00",
+}
+
+func FuzzStripQuotes(f *testing.F) {
+	for _, s := range quoteSeedInputs {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, s string) {
+		unquoted, opener := stripQuotes(s)
+
+		// Invariant 1: opener is one of {0, '"', '\''}; nothing else can leak.
+		if opener != 0 && opener != '"' && opener != '\'' {
+			t.Errorf("stripQuotes returned non-quote opener %q for %q", opener, s)
+		}
+
+		// Invariant 2: when opener is 0, the result is the input verbatim.
+		// stripQuotes never strips anything from a non-quote-led input.
+		if opener == 0 && unquoted != s {
+			t.Errorf("opener=0 but input changed: %q → %q", s, unquoted)
+		}
+
+		// Invariant 3: when opener is non-zero, the input started with that
+		// quote and the unquoted text does not start with another opener
+		// of the same kind. Catches accidental double-strip.
+		if opener != 0 {
+			if len(s) == 0 || rune(s[0]) != opener {
+				t.Errorf("opener %q but input %q didn't start with it", opener, s)
+			}
+			// stripQuotes removes at most two bytes (opener + matching
+			// closer); the result length must be within [len(s)-2, len(s)-1].
+			if len(unquoted) < len(s)-2 || len(unquoted) > len(s)-1 {
+				t.Errorf("stripQuotes removed unexpected byte count: %q (len %d) → %q (len %d)",
+					s, len(s), unquoted, len(unquoted))
+			}
+		}
+	})
+}
+
+func FuzzResolvePath(f *testing.F) {
+	for _, s := range quoteSeedInputs {
+		f.Add(s)
+	}
+	f.Fuzz(func(t *testing.T, typed string) {
+		const (
+			cwd  = "/work"
+			home = "/Users/jane"
+		)
+
+		// Run both expandTilde modes — neither must panic, hang, or return
+		// nonsensical offsets for any input.
+		for _, expand := range []bool{true, false} {
+			fullClean, parent, base, userPrefix := resolvePath(typed, cwd, home, expand)
+
+			// Invariant 1: empty input → all empty returns.
+			if typed == "" {
+				if fullClean != "" || parent != "" || base != "" || userPrefix != "" {
+					t.Errorf("empty input should return empty: full=%q parent=%q base=%q prefix=%q",
+						fullClean, parent, base, userPrefix)
+				}
+				continue
+			}
+
+			// Invariant 2: userPrefix is a prefix of the typed string after
+			// the bare-"~" normalisation (which converts "~" to "~/").
+			normalised := typed
+			if normalised == "~" {
+				normalised = "~/"
+			}
+			if userPrefix != "" && !startsWith(normalised, userPrefix) {
+				t.Errorf("userPrefix %q is not a prefix of normalised typed %q (raw %q)",
+					userPrefix, normalised, typed)
+			}
+
+			// Invariant 3: parent ends with a separator when base is empty.
+			// This is the contract candidate generation relies on.
+			if base == "" && parent != "" && !endsInSeparator(parent) {
+				t.Errorf("base is empty but parent %q doesn't end in a separator", parent)
+			}
+		}
+	})
+}
+
+// startsWith is a fuzz-helper alternative to strings.HasPrefix so the fuzz
+// target stays free of the strings package import within this file.
+func startsWith(s, prefix string) bool {
+	return len(s) >= len(prefix) && s[:len(prefix)] == prefix
+}
+
 func FuzzRender(f *testing.F) {
 	for _, s := range seedInputs {
 		f.Add(s)

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/dotopototo/bubblecomplete
 
-go 1.26.0
+go 1.26.1
 
 require (
 	charm.land/bubbles/v2 v2.1.0

--- a/model.go
+++ b/model.go
@@ -85,6 +85,33 @@ type Model struct {
 	// The icon for flag completions
 	FlagIcon string
 
+	// ---- Filesystem completion (opt-in) ----
+	//
+	// The fields below are public for parity with other Model knobs, but
+	// changes made after construction are picked up on the NEXT input
+	// change — pathState and m.completions are not refreshed in place.
+	// Hosts that need an immediate refresh after toggling at runtime can
+	// force one by re-typing or by clearing and re-setting input.
+
+	// FilesystemCompletions enables live filesystem completion and validity
+	// colouring for FileArgument, DirArgument, and FileDirArgument values.
+	// Default false. Hosts that don't enable this see the pre-feature
+	// behaviour unchanged.
+	FilesystemCompletions bool
+	// FilesystemCompletionLimit caps the per-keystroke candidate count.
+	// Default 200. Values ≤ 0 are clamped to 1 at the use site.
+	FilesystemCompletionLimit int
+	// HiddenFiles surfaces dotfiles in completions even when the typed
+	// basename prefix does not start with ".". Default false.
+	HiddenFiles bool
+
+	// pathCache is lazily initialised on first use by recomputePathState.
+	pathCache *dirCache
+	// pathState is the per-keystroke result of activeFileArgument plus
+	// classification and candidate generation. Read by Render and the
+	// validation-style suppression.
+	pathState pathState
+
 	styles Styles
 	keymap KeyMap
 }
@@ -288,26 +315,29 @@ func New(commands []*Command, width int, opts ...Option) (Model, error) {
 	input.KeyMap = inputKeyMap
 
 	m := Model{
-		input:               input,
-		Commands:            commands,
-		width:               width,
-		completionIndex:     -1,
-		historyIndex:        -1,
-		HistoryLimit:        100,
-		Autotrim:            true,
-		IndentCompletions:   true,
-		CompletionsOffset:   0,
-		ShowBorderScroll:    false,
-		ShowScrollbar:       false,
-		CompletionsPosition: PositionBelow,
-		CompletionRows:      5,
-		ShowIcons:           false,
-		ShowDescriptions:    true,
-		CommandIcon:         "\u203A",
-		ArgumentIcon:        "\u25C6",
-		FlagIcon:            "\u25C7",
-		styles:              DefaultStyles(),
-		keymap:              DefaultKeyMap(),
+		input:                     input,
+		Commands:                  commands,
+		width:                     width,
+		completionIndex:           -1,
+		historyIndex:              -1,
+		HistoryLimit:              100,
+		Autotrim:                  true,
+		IndentCompletions:         true,
+		CompletionsOffset:         0,
+		ShowBorderScroll:          false,
+		ShowScrollbar:             false,
+		CompletionsPosition:       PositionBelow,
+		CompletionRows:            5,
+		ShowIcons:                 false,
+		ShowDescriptions:          true,
+		CommandIcon:               "\u203A",
+		ArgumentIcon:              "\u25C6",
+		FlagIcon:                  "\u25C7",
+		FilesystemCompletions:     false,
+		FilesystemCompletionLimit: 200,
+		HiddenFiles:               false,
+		styles:                    DefaultStyles(),
+		keymap:                    DefaultKeyMap(),
 	}
 	for _, opt := range opts {
 		opt(&m)

--- a/model.go
+++ b/model.go
@@ -360,9 +360,14 @@ func (m *Model) SetStyles(s Styles) {
 // applyInputValidationStyle pushes the current valid/invalid input style into
 // the embedded textinput so Render stays free of side effects. Call after any
 // change to validationErr or styles.
+//
+// When the user is mid-typing a partial filesystem path that resolves to
+// PathNotFound, the whole-input invalid style is suppressed — the path-range
+// overlay (PathPartial) provides the in-progress signal instead. Other
+// validation errors still drive whole-input red.
 func (m *Model) applyInputValidationStyle() {
 	style := m.styles.Input.Valid
-	if m.validationErr != nil {
+	if m.validationErr != nil && !m.isPartialPathMidType() {
 		style = m.styles.Input.Invalid
 	}
 	s := m.input.Styles()

--- a/options.go
+++ b/options.go
@@ -96,3 +96,29 @@ func WithKeyMap(k KeyMap) Option {
 func WithStyles(s Styles) Option {
 	return func(m *Model) { m.SetStyles(s) }
 }
+
+// WithFilesystemCompletions enables live filesystem completion for values
+// bound to FileArgument, DirArgument, or FileDirArgument. Default false.
+//
+// When enabled, the completion list for an active file/dir value is replaced
+// wholesale with matching entries from the relevant parent directory. Tab
+// cycles through candidates the same way it does for command/flag rows.
+// See also [WithFilesystemCompletionLimit] and [WithHiddenFiles].
+func WithFilesystemCompletions(b bool) Option {
+	return func(m *Model) { m.FilesystemCompletions = b }
+}
+
+// WithFilesystemCompletionLimit caps the number of filesystem candidates
+// shown per keystroke. Default 200. Values ≤ 0 are clamped to 1 at the
+// use site (so direct mutation of the public field is safe).
+func WithFilesystemCompletionLimit(n int) Option {
+	return func(m *Model) { m.FilesystemCompletionLimit = n }
+}
+
+// WithHiddenFiles surfaces dotfiles in filesystem completion candidates
+// even when the typed basename prefix does not start with ".". Default
+// false (dotfiles only surface when the user explicitly types a leading
+// "."). Has no effect when WithFilesystemCompletions is false.
+func WithHiddenFiles(b bool) Option {
+	return func(m *Model) { m.HiddenFiles = b }
+}

--- a/path_integration_test.go
+++ b/path_integration_test.go
@@ -1,0 +1,282 @@
+package bubblecomplete
+
+import (
+	"path/filepath"
+	"testing"
+
+	tea "charm.land/bubbletea/v2"
+)
+
+// pathTestCommands constructs a minimal set of test commands tailored to
+// exercising the Phase 3 Update integration without depending on the
+// project-wide TestCommands fixture.
+func pathTestCommands() []*Command {
+	return []*Command{
+		{
+			Command: "cat",
+			PositionalArguments: []*PositionalArgument{
+				{Name: "File", Type: FileArgument, Required: true},
+			},
+		},
+		{
+			Command: "cd",
+			PositionalArguments: []*PositionalArgument{
+				{Name: "Dir", Type: DirArgument, Required: true},
+			},
+		},
+		{
+			Command: "find",
+			PositionalArguments: []*PositionalArgument{
+				{Name: "Dir", Type: DirArgument, Required: true},
+			},
+			Flags: []*Flag{
+				{LongFlag: "--path", Type: FileArgument},
+			},
+		},
+		{
+			Command: "echo",
+			PositionalArguments: []*PositionalArgument{
+				{Name: "Msg", Type: StringArgument, Required: true},
+			},
+		},
+	}
+}
+
+func newPathTestModel(t *testing.T, enable bool) Model {
+	t.Helper()
+	opts := []Option{}
+	if enable {
+		opts = append(opts, WithFilesystemCompletions(true))
+	}
+	m, err := New(pathTestCommands(), 100, opts...)
+	if err != nil {
+		t.Fatal(err)
+	}
+	return m
+}
+
+func TestRecomputePathState_DisabledIsInactive(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+	m := newPathTestModel(t, false)
+	m = simulateTyping(t, m, "cat "+filepath.Join(dir, "fo"))
+	if m.pathState.active {
+		t.Errorf("pathState.active = true when feature disabled")
+	}
+}
+
+func TestRecomputePathState_EnabledPopulatesState(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+	m := newPathTestModel(t, true)
+	m = simulateTyping(t, m, "cat "+filepath.Join(dir, "fo"))
+
+	if !m.pathState.active {
+		t.Fatal("pathState.active = false, want true")
+	}
+	if m.pathState.kind != FileArgument {
+		t.Errorf("kind = %v, want FileArgument", m.pathState.kind)
+	}
+	if m.pathState.validity != pathPartial {
+		t.Errorf("validity = %d, want pathPartial", m.pathState.validity)
+	}
+	if !pathCandidateNames(m.pathState.candidates).has("foo.txt") {
+		t.Errorf("candidates missing foo.txt: %v", pathCandidateNames(m.pathState.candidates))
+	}
+}
+
+func TestRecomputePathState_ExactFileIsValid(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+	m := newPathTestModel(t, true)
+	m = simulateTyping(t, m, "cat "+filepath.Join(dir, "foo.txt"))
+
+	if !m.pathState.active {
+		t.Fatal("expected active")
+	}
+	if m.pathState.validity != pathValid {
+		t.Errorf("validity = %d, want pathValid", m.pathState.validity)
+	}
+}
+
+func TestRecomputePathState_StringArgIsInactive(t *testing.T) {
+	m := newPathTestModel(t, true)
+	m = simulateTyping(t, m, "echo hello")
+	if m.pathState.active {
+		t.Errorf("string arg should not trigger active path state")
+	}
+}
+
+func TestGetCompletions_WholesaleReplaceWhenActive(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "alpha.txt"))
+	mustWriteFile(t, filepath.Join(dir, "beta.txt"))
+	m := newPathTestModel(t, true)
+	m = simulateTyping(t, m, "cat "+filepath.Join(dir, "a"))
+
+	if len(m.completions) == 0 {
+		t.Fatal("expected at least one completion")
+	}
+	for _, c := range m.completions {
+		if _, ok := c.(pathCompletion); !ok {
+			t.Errorf("expected pathCompletion, got %T (%q)", c, c.getName())
+		}
+	}
+}
+
+func TestEmptyInputClearsPathStateWithoutValidationErr(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+	m := newPathTestModel(t, true)
+	full := filepath.Join(dir, "foo.txt")
+	m = simulateTyping(t, m, "cat "+full)
+
+	if !m.pathState.active || m.pathState.validity != pathValid {
+		t.Fatal("setup: expected active pathValid state")
+	}
+	if m.validationErr != nil {
+		t.Fatalf("setup: expected nil validationErr (valid file), got %v", m.validationErr)
+	}
+
+	// Backspace through the entire input. Each backspace runs the input-
+	// changed branch; the final transition to empty should reset pathState
+	// even though there's no validationErr to clear.
+	for range len("cat " + full) {
+		m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyBackspace})
+	}
+
+	if m.input.Value() != "" {
+		t.Fatalf("setup: expected empty value after backspace loop, got %q", m.input.Value())
+	}
+	if m.pathState.active {
+		t.Errorf("pathState should be cleared after input emptied")
+	}
+}
+
+func TestResetModelClearsPathState(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+	m := newPathTestModel(t, true)
+	m = simulateTyping(t, m, "cat "+filepath.Join(dir, "foo.txt"))
+	if !m.pathState.active {
+		t.Fatal("setup: expected active state")
+	}
+	m = m.resetModel()
+	if m.pathState.active {
+		t.Errorf("resetModel did not clear pathState")
+	}
+}
+
+// TestTabAccept_EqualsFormRegressionGuard locks in the v4 regression: the
+// Phase 3 wiring must not drop the "--path=" prefix when Tab-accepting a
+// path completion. This exercises the full Update flow with simulateTyping.
+func TestTabAccept_EqualsFormRegressionGuard(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "report.txt"))
+
+	m := newPathTestModel(t, true)
+	// Type "find . --path=<dir>/rep"
+	m = simulateTyping(t, m, "find . --path="+filepath.Join(dir, "rep"))
+
+	if !m.pathState.active {
+		t.Fatal("expected active path state")
+	}
+	if !pathCandidateNames(m.pathState.candidates).has("report.txt") {
+		t.Fatalf("expected report.txt candidate: %v", pathCandidateNames(m.pathState.candidates))
+	}
+
+	// Tab to accept the first candidate.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+
+	want := "find . --path=" + filepath.Join(dir, "report.txt")
+	if got := m.input.Value(); got != want {
+		t.Errorf("after Tab: %q, want %q", got, want)
+	}
+}
+
+func TestTabAccept_PositionalFile(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "alpha.txt"))
+
+	m := newPathTestModel(t, true)
+	m = simulateTyping(t, m, "cat "+filepath.Join(dir, "alph"))
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+
+	want := "cat " + filepath.Join(dir, "alpha.txt")
+	if got := m.input.Value(); got != want {
+		t.Errorf("Tab insertion = %q, want %q", got, want)
+	}
+}
+
+func TestTabAccept_PositionalDirAddsTrailingSlash(t *testing.T) {
+	dir := t.TempDir()
+	mustMkdir(t, filepath.Join(dir, "subdir"))
+
+	m := newPathTestModel(t, true)
+	m = simulateTyping(t, m, "cd "+filepath.Join(dir, "sub"))
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+
+	want := "cd " + filepath.Join(dir, "subdir") + "/"
+	if got := m.input.Value(); got != want {
+		t.Errorf("Tab insertion = %q, want %q", got, want)
+	}
+}
+
+func TestTabAccept_QuotedPositional(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "alpha.txt"))
+
+	m := newPathTestModel(t, true)
+	m = simulateTyping(t, m, `cat "`+filepath.Join(dir, "alph"))
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+
+	want := `cat "` + filepath.Join(dir, "alpha.txt") + `"`
+	if got := m.input.Value(); got != want {
+		t.Errorf("Tab insertion = %q, want %q", got, want)
+	}
+}
+
+func TestTabAccept_TildeExpansion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	mustWriteFile(t, filepath.Join(home, "report.txt"))
+
+	m := newPathTestModel(t, true)
+	m = simulateTyping(t, m, "cat ~/rep")
+
+	if !pathCandidateNames(m.pathState.candidates).has("report.txt") {
+		t.Fatalf("expected report.txt under ~/: %v", pathCandidateNames(m.pathState.candidates))
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+
+	// userPrefix is preserved verbatim, so the result keeps "~/", not the
+	// expanded $HOME path.
+	want := "cat ~/report.txt"
+	if got := m.input.Value(); got != want {
+		t.Errorf("Tab insertion = %q, want %q", got, want)
+	}
+}
+
+// pathCandidateNames is a small helper for set-style assertions.
+type pathCandidateNames []pathCompletion
+
+func (p pathCandidateNames) has(name string) bool {
+	for _, c := range p {
+		if c.displayName == name {
+			return true
+		}
+	}
+	return false
+}
+
+func (p pathCandidateNames) String() string {
+	names := make([]string, len(p))
+	for i, c := range p {
+		names[i] = c.displayName
+	}
+	return "[" + filepath.Join(names...) + "]"
+}

--- a/path_integration_test.go
+++ b/path_integration_test.go
@@ -616,6 +616,168 @@ func TestRender_WholeInputNotInvalidForPartialPathNotFound(t *testing.T) {
 	}
 }
 
+// TestHistoryNav_RefreshesPathState verifies that pulling a historic value
+// via Up arrow triggers the input-changed branch and refreshes pathState
+// against the historic path. Without this, the overlay would still
+// reflect whatever was on screen before Up — typically nothing for a
+// fresh model.
+func TestHistoryNav_RefreshesPathState(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+	historic := "cat " + filepath.Join(dir, "foo.txt")
+
+	m, err := New(pathTestCommands(), 500, WithFilesystemCompletions(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Seed history manually; the integration here is the Up → SetValue →
+	// input-changed branch chain, not the submit-saves-history path.
+	m.History = []string{historic}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyUp})
+
+	if m.input.Value() != historic {
+		t.Fatalf("after Up: input %q, want historic %q", m.input.Value(), historic)
+	}
+	if !m.pathState.active {
+		t.Errorf("pathState should be active after history nav loaded a path")
+	}
+	if m.pathState.validity != pathValid {
+		t.Errorf("historic path resolves to a real file → expected pathValid, got %d", m.pathState.validity)
+	}
+}
+
+// TestPsFlagWithFileArgument exercises the PowerShell-style flag form
+// (`-Path value` and `-Path=value`) carrying a FileArgument. Both code
+// paths in activeFileArgument (Case 1 equals-form, Case 2 space-separated)
+// branch on LongFlag OR PsFlag — these tests confirm the PsFlag branch
+// works end-to-end, not just the LongFlag side that the rest of the suite
+// already exercises.
+func TestPsFlagWithFileArgument(t *testing.T) {
+	psCmd := &Command{
+		Command: "ps",
+		PositionalArguments: []*PositionalArgument{
+			{Name: "Cmd", Type: StringArgument, Required: true},
+		},
+		Flags: []*Flag{
+			{PsFlag: "-Path", Type: FileArgument},
+		},
+	}
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "alpha.txt"))
+
+	t.Run("equals-form", func(t *testing.T) {
+		m, err := New([]*Command{psCmd}, 500, WithFilesystemCompletions(true))
+		if err != nil {
+			t.Fatal(err)
+		}
+		m = simulateTyping(t, m, "ps run -Path="+filepath.Join(dir, "alph"))
+		if !m.pathState.active {
+			t.Fatal("expected pathState active for -Path=<partial>")
+		}
+		if m.pathState.kind != FileArgument {
+			t.Errorf("kind = %v, want FileArgument", m.pathState.kind)
+		}
+		if !pathCandidateNames(m.pathState.candidates).has("alpha.txt") {
+			t.Errorf("expected alpha.txt candidate, got %v", pathCandidateNames(m.pathState.candidates))
+		}
+	})
+
+	t.Run("space-separated", func(t *testing.T) {
+		m, err := New([]*Command{psCmd}, 500, WithFilesystemCompletions(true))
+		if err != nil {
+			t.Fatal(err)
+		}
+		m = simulateTyping(t, m, "ps run -Path "+filepath.Join(dir, "alph"))
+		if !m.pathState.active {
+			t.Fatal("expected pathState active for -Path <partial>")
+		}
+		if m.pathState.kind != FileArgument {
+			t.Errorf("kind = %v, want FileArgument", m.pathState.kind)
+		}
+		if !pathCandidateNames(m.pathState.candidates).has("alpha.txt") {
+			t.Errorf("expected alpha.txt candidate, got %v", pathCandidateNames(m.pathState.candidates))
+		}
+	})
+}
+
+// TestKeyRight_DrillDownAfterCyclingDir is the explicit accept-and-recompute
+// flow for a path candidate. With two matching dirs, Tab enters cycling,
+// Right accepts the cycled candidate AND triggers a recompute, then the
+// next Tab cycles among the accepted dir's children. The Tab → Right →
+// Tab pattern is the natural drill-down for a host that maps the accept
+// key to Right.
+func TestKeyRight_DrillDownAfterCyclingDir(t *testing.T) {
+	dir := t.TempDir()
+	mustMkdir(t, filepath.Join(dir, "doc1"))
+	mustWriteFile(t, filepath.Join(dir, "doc1", "child.txt"))
+	mustMkdir(t, filepath.Join(dir, "doc2"))
+
+	m, err := New(pathTestCommands(), 500, WithFilesystemCompletions(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = simulateTyping(t, m, "cat "+filepath.Join(dir, "doc"))
+
+	// Tab enters cycling on the first dir candidate.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.completionHolder == "" {
+		t.Fatal("setup: expected Tab to enter cycling state (2 dir candidates)")
+	}
+	cycledValue := m.input.Value()
+
+	// Right accepts the cycled candidate and exits cycling — completionHolder
+	// clears, input-changed branch fires, recompute populates child candidates.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyRight})
+	if m.completionHolder != "" {
+		t.Errorf("Right should have cleared completionHolder, got %q", m.completionHolder)
+	}
+	if m.input.Value() != cycledValue {
+		t.Errorf("Right should not change input value: was %q, now %q", cycledValue, m.input.Value())
+	}
+	if !pathCandidateNames(m.pathState.candidates).has("child.txt") {
+		t.Fatalf("expected child.txt in candidates after Right-accept of doc1/; got %v",
+			pathCandidateNames(m.pathState.candidates))
+	}
+
+	// Next Tab drills into the single child (auto-accept on single match).
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	want := "cat " + filepath.Join(dir, "doc1", "child.txt") + " "
+	if got := m.input.Value(); got != want {
+		t.Errorf("after drill-down Tab: %q, want %q", got, want)
+	}
+}
+
+// TestRuntimeToggle_FilesystemCompletions verifies the documented behaviour
+// for direct field mutation: changes to FilesystemCompletions take effect
+// on the NEXT input change, not in place. The field is public for parity
+// with other Model knobs, but pathState is not refreshed eagerly when a
+// host flips the flag — the host must produce an input event (typing,
+// backspace, etc.) to trigger a recompute.
+func TestRuntimeToggle_FilesystemCompletions(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+
+	m := newPathTestModel(t, false)
+	m = simulateTyping(t, m, "cat "+filepath.Join(dir, "fo"))
+	if m.pathState.active {
+		t.Fatal("setup: feature disabled, pathState should be inactive")
+	}
+
+	// Toggle on directly — no input event yet, so pathState stays stale.
+	m.FilesystemCompletions = true
+	if m.pathState.active {
+		t.Errorf("toggling FilesystemCompletions should NOT refresh pathState in place")
+	}
+
+	// Type one more character → input-changed branch fires → recompute
+	// runs with the toggle now on → pathState becomes active.
+	m = simulateTyping(t, m, "o")
+	if !m.pathState.active {
+		t.Errorf("after next input event, pathState should be active (feature now on)")
+	}
+}
+
 // pathCandidateNames is a small helper for set-style assertions.
 type pathCandidateNames []pathCompletion
 

--- a/path_integration_test.go
+++ b/path_integration_test.go
@@ -398,13 +398,61 @@ func TestSuppression_FiresWhenErrorMatchesActiveArg(t *testing.T) {
 	}
 }
 
+// TestTabAutoAcceptDrillsIntoUniqueDir locks in the bash-like single-match
+// auto-accept behaviour: typing a prefix that uniquely matches a directory
+// and pressing Tab should accept it (input now ends in "uniquedir/") AND
+// exit cycling state so the next Tab lists the directory's children. Two
+// Tabs in a row drill one level deep.
+//
+// Uses cat (FileArgument) because FileArgument candidates include files
+// inside the drilled-into dir — exercising the auto-accept-then-recompute
+// path end-to-end. DirArgument would filter the file child out (dirs only)
+// which would make the drill-down land on empty candidates.
+func TestTabAutoAcceptDrillsIntoUniqueDir(t *testing.T) {
+	dir := t.TempDir()
+	mustMkdir(t, filepath.Join(dir, "uniquedir"))
+	mustWriteFile(t, filepath.Join(dir, "uniquedir", "child.txt"))
+
+	m, err := New(pathTestCommands(), 500, WithFilesystemCompletions(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = simulateTyping(t, m, "cat "+filepath.Join(dir, "uniq"))
+
+	// First Tab: single match → auto-accept, no cycling state, recompute
+	// runs the same Update tick.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	wantAfterFirst := "cat " + filepath.Join(dir, "uniquedir") + "/"
+	if got := m.input.Value(); got != wantAfterFirst {
+		t.Fatalf("after first Tab: got %q, want %q", got, wantAfterFirst)
+	}
+	if m.completionHolder != "" || m.completionIndex != -1 {
+		t.Errorf("single-match Tab should clear cycling state; holder=%q index=%d",
+			m.completionHolder, m.completionIndex)
+	}
+	if !pathCandidateNames(m.pathState.candidates).has("child.txt") {
+		t.Fatalf("expected child.txt candidate after auto-accept drill-down: %v",
+			pathCandidateNames(m.pathState.candidates))
+	}
+
+	// Second Tab: single child auto-accepts again, drilling to the file.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	wantAfterSecond := "cat " + filepath.Join(dir, "uniquedir", "child.txt")
+	if got := m.input.Value(); got != wantAfterSecond {
+		t.Errorf("after second Tab: got %q, want %q", got, wantAfterSecond)
+	}
+}
+
 // TestRender_OverlayBypassedDuringCompletionCycling locks in that the
 // overlay is skipped while the user is cycling Tab completions. Without
 // the bypass, the frozen pathState offsets would mis-style the cycled
 // preview value.
 func TestRender_OverlayBypassedDuringCompletionCycling(t *testing.T) {
 	dir := t.TempDir()
+	// Two files with the same prefix → Tab enters cycling state. A single
+	// match would auto-accept and skip cycling entirely.
 	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+	mustWriteFile(t, filepath.Join(dir, "fox.txt"))
 
 	// Width must comfortably exceed the temp-dir path or the overflow
 	// guard, not the cycling bypass, would be what produces the

--- a/path_integration_test.go
+++ b/path_integration_test.go
@@ -185,10 +185,11 @@ func TestTabAccept_EqualsFormRegressionGuard(t *testing.T) {
 		t.Fatalf("expected report.txt candidate: %v", pathCandidateNames(m.pathState.candidates))
 	}
 
-	// Tab to accept the first candidate.
+	// Tab to accept the first candidate. File completions append a
+	// trailing space (bash-style "this token is done").
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 
-	want := "find . --path=" + filepath.Join(dir, "report.txt")
+	want := "find . --path=" + filepath.Join(dir, "report.txt") + " "
 	if got := m.input.Value(); got != want {
 		t.Errorf("after Tab: %q, want %q", got, want)
 	}
@@ -203,7 +204,8 @@ func TestTabAccept_PositionalFile(t *testing.T) {
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 
-	want := "cat " + filepath.Join(dir, "alpha.txt")
+	// File completions get a trailing space.
+	want := "cat " + filepath.Join(dir, "alpha.txt") + " "
 	if got := m.input.Value(); got != want {
 		t.Errorf("Tab insertion = %q, want %q", got, want)
 	}
@@ -233,7 +235,8 @@ func TestTabAccept_QuotedPositional(t *testing.T) {
 
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 
-	want := `cat "` + filepath.Join(dir, "alpha.txt") + `"`
+	// File completions get a trailing space AFTER the closing quote.
+	want := `cat "` + filepath.Join(dir, "alpha.txt") + `" `
 	if got := m.input.Value(); got != want {
 		t.Errorf("Tab insertion = %q, want %q", got, want)
 	}
@@ -254,8 +257,8 @@ func TestTabAccept_TildeExpansion(t *testing.T) {
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 
 	// userPrefix is preserved verbatim, so the result keeps "~/", not the
-	// expanded $HOME path.
-	want := "cat ~/report.txt"
+	// expanded $HOME path. File completion appends a trailing space.
+	want := "cat ~/report.txt "
 	if got := m.input.Value(); got != want {
 		t.Errorf("Tab insertion = %q, want %q", got, want)
 	}
@@ -436,8 +439,9 @@ func TestTabAutoAcceptDrillsIntoUniqueDir(t *testing.T) {
 	}
 
 	// Second Tab: single child auto-accepts again, drilling to the file.
+	// File completion appends a trailing space.
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
-	wantAfterSecond := "cat " + filepath.Join(dir, "uniquedir", "child.txt")
+	wantAfterSecond := "cat " + filepath.Join(dir, "uniquedir", "child.txt") + " "
 	if got := m.input.Value(); got != wantAfterSecond {
 		t.Errorf("after second Tab: got %q, want %q", got, wantAfterSecond)
 	}

--- a/path_integration_test.go
+++ b/path_integration_test.go
@@ -261,6 +261,203 @@ func TestTabAccept_TildeExpansion(t *testing.T) {
 	}
 }
 
+// renderWithFeature is a small helper that builds a model with the feature
+// toggled to `on`, types `input`, and returns the rendered output.
+func renderWithFeature(t *testing.T, on bool, input string) string {
+	t.Helper()
+	m := newPathTestModel(t, on)
+	m = simulateTyping(t, m, input)
+	return m.Render()
+}
+
+// TestRender_OverlayChangesOutputByValidity asserts that the rendered output
+// differs between valid/partial/invalid validity classes when the feature
+// is enabled — i.e. the overlay is applied and the chosen style differs by
+// classification. The exact ANSI bytes are not asserted (lipgloss merges
+// styles when overlaying via StyleRanges, so the precise output isn't
+// trivially reconstructable). Asserting pairwise inequality is the
+// strongest observation we can make without coupling to internal ANSI
+// codes.
+func TestRender_OverlayChangesOutputByValidity(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+
+	valid := renderWithFeature(t, true, "cat "+filepath.Join(dir, "foo.txt"))
+	partial := renderWithFeature(t, true, "cat "+filepath.Join(dir, "fo"))
+	invalid := renderWithFeature(t, true, "cat "+filepath.Join(dir, "zzz_nope"))
+
+	if valid == partial {
+		t.Errorf("valid and partial renders should differ (overlay style not changing)")
+	}
+	if valid == invalid {
+		t.Errorf("valid and invalid renders should differ")
+	}
+	if partial == invalid {
+		t.Errorf("partial and invalid renders should differ")
+	}
+}
+
+// TestRender_OverlayPresentWhenFeatureEnabled asserts that enabling the
+// feature produces a different rendered output than leaving it disabled,
+// holding all other state equal. The byte-level difference proves that
+// styleInputPathRange wrote something to the output.
+func TestRender_OverlayPresentWhenFeatureEnabled(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+	full := filepath.Join(dir, "foo.txt")
+
+	on := renderWithFeature(t, true, "cat "+full)
+	off := renderWithFeature(t, false, "cat "+full)
+	if on == off {
+		t.Errorf("feature-on render should differ from feature-off render")
+	}
+}
+
+// TestRender_OverlaySkippedWhenOverflow asserts that an input wider than
+// m.width bypasses the overlay rather than painting garbage. The test
+// compares renderedInput against the raw textinput.View directly — the
+// only thing renderedInput should add when active is the StyleRanges
+// overlay, so when the overflow guard fires, those outputs must match.
+func TestRender_OverlaySkippedWhenOverflow(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+	input := "cat " + filepath.Join(dir, "foo.txt")
+
+	m, err := New(pathTestCommands(), 8, WithFilesystemCompletions(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = simulateTyping(t, m, input)
+	if !m.pathState.active {
+		t.Fatal("setup: expected pathState.active=true")
+	}
+	if m.renderedInput() != m.input.View() {
+		t.Errorf("overflow case should bypass overlay:\n  got %q\n want %q",
+			m.renderedInput(), m.input.View())
+	}
+}
+
+// TestRender_EqualsFormOverlayDiffers ensures the equals-form rendering
+// changes when the feature is enabled — the value portion gets the
+// overlay even though tokenPrefix ("--path=") is in the same token.
+func TestRender_EqualsFormOverlayDiffers(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "report.txt"))
+	input := "find . --path=" + filepath.Join(dir, "report.txt")
+	if renderWithFeature(t, true, input) == renderWithFeature(t, false, input) {
+		t.Errorf("equals-form render should differ between feature on/off")
+	}
+}
+
+// TestSuppression_DoesNotHideErrorFromOtherArg verifies that when one
+// path argument is invalid (PathNotFound from a committed token) and a
+// LATER positional is a partial path, the whole-input red is NOT
+// suppressed — the validation error belongs to a different token.
+func TestSuppression_DoesNotHideErrorFromOtherArg(t *testing.T) {
+	cmd := &Command{
+		Command: "twopath",
+		PositionalArguments: []*PositionalArgument{
+			{Name: "first", Type: FileArgument, Required: true},
+			{Name: "second", Type: DirArgument, Required: true},
+		},
+	}
+	dir := t.TempDir()
+	mustMkdir(t, filepath.Join(dir, "subdir"))
+
+	m, err := New([]*Command{cmd}, 200, WithFilesystemCompletions(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// First path: definitely-missing. Second path: prefix of "subdir/".
+	input := "twopath " + filepath.Join(dir, "missing") + " " + filepath.Join(dir, "sub")
+	m = simulateTyping(t, m, input)
+
+	if m.validationErr == nil {
+		t.Fatal("setup: expected validationErr from first path")
+	}
+	if !m.pathState.active || m.pathState.validity != pathPartial {
+		t.Fatalf("setup: expected active+partial for second path; got active=%v validity=%d",
+			m.pathState.active, m.pathState.validity)
+	}
+	if m.isPartialPathMidType() {
+		t.Errorf("suppression must NOT fire: validation error belongs to a different argument")
+	}
+}
+
+// TestSuppression_FiresWhenErrorMatchesActiveArg confirms the positive case
+// — single path argument, partial typing, error matches → suppression fires.
+func TestSuppression_FiresWhenErrorMatchesActiveArg(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+	m := newPathTestModel(t, true)
+	m = simulateTyping(t, m, "cat "+filepath.Join(dir, "fo"))
+
+	if !m.isPartialPathMidType() {
+		t.Errorf("expected suppression to fire for single-arg partial path")
+	}
+}
+
+// TestRender_OverlayBypassedDuringCompletionCycling locks in that the
+// overlay is skipped while the user is cycling Tab completions. Without
+// the bypass, the frozen pathState offsets would mis-style the cycled
+// preview value.
+func TestRender_OverlayBypassedDuringCompletionCycling(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+
+	// Width must comfortably exceed the temp-dir path or the overflow
+	// guard, not the cycling bypass, would be what produces the
+	// no-overlay state — defeating the test.
+	m, err := New(pathTestCommands(), 500, WithFilesystemCompletions(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = simulateTyping(t, m, "cat "+filepath.Join(dir, "fo"))
+
+	beforeTab := m.renderedInput()
+	rawBeforeTab := m.input.View()
+	if beforeTab == rawBeforeTab {
+		t.Fatal("setup: expected overlay to be applied before Tab (width may be too small)")
+	}
+
+	// Tab to begin cycling — input.Value updates to the candidate, but
+	// pathState stays frozen. renderedInput should bypass the overlay.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.completionHolder == "" {
+		t.Fatal("setup: expected Tab to enter cycling state")
+	}
+	if m.renderedInput() != m.input.View() {
+		t.Errorf("overlay should be bypassed during cycling:\n  got %q\n want %q",
+			m.renderedInput(), m.input.View())
+	}
+}
+
+func TestRender_WholeInputNotInvalidForPartialPathNotFound(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
+	m := newPathTestModel(t, true)
+	partial := filepath.Join(dir, "fo")
+	m = simulateTyping(t, m, "cat "+partial)
+
+	// Setup invariant: partial path resolves to PathNotFound at submit time,
+	// but classifier reports pathPartial — suppression should fire.
+	if m.pathState.validity != pathPartial {
+		t.Fatalf("setup: expected pathPartial, got %d", m.pathState.validity)
+	}
+	if !m.isPartialPathMidType() {
+		t.Fatalf("setup: expected isPartialPathMidType=true (validationErr=%v)", m.validationErr)
+	}
+
+	// The textinput's Focused.Text style should be the Valid style, not
+	// Invalid, because the suppression rule fired.
+	got := m.input.Styles().Focused.Text.Render("sample")
+	want := m.Styles().Input.Valid.Render("sample")
+	if got != want {
+		t.Errorf("expected suppression to keep Valid style; got %q want %q", got, want)
+	}
+}
+
 // pathCandidateNames is a small helper for set-style assertions.
 type pathCandidateNames []pathCompletion
 

--- a/path_integration_test.go
+++ b/path_integration_test.go
@@ -447,41 +447,147 @@ func TestTabAutoAcceptDrillsIntoUniqueDir(t *testing.T) {
 	}
 }
 
-// TestRender_OverlayBypassedDuringCompletionCycling locks in that the
-// overlay is skipped while the user is cycling Tab completions. Without
-// the bypass, the frozen pathState offsets would mis-style the cycled
-// preview value.
-func TestRender_OverlayBypassedDuringCompletionCycling(t *testing.T) {
+// TestRender_OverlayInactiveDuringFileCycling locks in the natural
+// interaction between the bash-style trailing-space-after-files rule and
+// the per-cycle pathState refresh: cycled FILE candidates have a trailing
+// space, which makes activeFileArgument inactive, which skips the
+// overlay. Users cycling between file candidates see no validity colour
+// — but the cycled values are all real files by construction (they came
+// from generateCandidates' kind filter), so the missing colour carries
+// no information.
+func TestRender_OverlayInactiveDuringFileCycling(t *testing.T) {
 	dir := t.TempDir()
-	// Two files with the same prefix → Tab enters cycling state. A single
-	// match would auto-accept and skip cycling entirely.
+	// Two files with the same prefix → Tab enters cycling state.
 	mustWriteFile(t, filepath.Join(dir, "foo.txt"))
 	mustWriteFile(t, filepath.Join(dir, "fox.txt"))
 
 	// Width must comfortably exceed the temp-dir path or the overflow
-	// guard, not the cycling bypass, would be what produces the
-	// no-overlay state — defeating the test.
+	// guard (not the trailing-space-makes-inactive interaction) would be
+	// what produces the no-overlay state — defeating the test.
 	m, err := New(pathTestCommands(), 500, WithFilesystemCompletions(true))
 	if err != nil {
 		t.Fatal(err)
 	}
 	m = simulateTyping(t, m, "cat "+filepath.Join(dir, "fo"))
 
-	beforeTab := m.renderedInput()
-	rawBeforeTab := m.input.View()
-	if beforeTab == rawBeforeTab {
-		t.Fatal("setup: expected overlay to be applied before Tab (width may be too small)")
+	if m.renderedInput() == m.input.View() {
+		t.Fatal("setup: expected overlay to be applied before Tab")
 	}
 
-	// Tab to begin cycling — input.Value updates to the candidate, but
-	// pathState stays frozen. renderedInput should bypass the overlay.
 	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
 	if m.completionHolder == "" {
 		t.Fatal("setup: expected Tab to enter cycling state")
 	}
+	// Cycled file value ends in trailing space → pathState refresh sees
+	// HasSuffix(input, " ") and returns inactive. Overlay skipped.
+	if m.pathState.active {
+		t.Errorf("expected pathState inactive after cycling to a file (trailing space); active=true")
+	}
 	if m.renderedInput() != m.input.View() {
-		t.Errorf("overlay should be bypassed during cycling:\n  got %q\n want %q",
+		t.Errorf("overlay should be skipped for cycled file (trailing space):\n  got %q\n want %q",
 			m.renderedInput(), m.input.View())
+	}
+}
+
+// TestRender_OverlayAppliesDuringDirCycling is the dir-specific counterpart
+// to the file-cycling test: cycled directory candidates end with "/" (no
+// trailing space), so pathState refresh keeps the overlay active with the
+// correct cycled-value offsets. The overlay therefore reflects the
+// classification of the cycled directory candidate (partial for FileArg
+// drill-down, valid for DirArg target).
+func TestRender_OverlayAppliesDuringDirCycling(t *testing.T) {
+	dir := t.TempDir()
+	mustMkdir(t, filepath.Join(dir, "doc1"))
+	mustMkdir(t, filepath.Join(dir, "doc2"))
+
+	m, err := New(pathTestCommands(), 500, WithFilesystemCompletions(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	m = simulateTyping(t, m, "cd "+filepath.Join(dir, "doc"))
+	if !m.pathState.active {
+		t.Fatal("setup: expected active pathState for partial dir match")
+	}
+
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.completionHolder == "" {
+		t.Fatal("setup: expected Tab to enter cycling state (multiple dir candidates)")
+	}
+	// pathState should be refreshed to reflect the cycled value
+	// "cd <dir>/doc1/" (or doc2). base is empty (trailing /), DirArgument
+	// classifies as pathValid.
+	if !m.pathState.active {
+		t.Errorf("expected pathState ACTIVE during dir cycling; active=false")
+	}
+	if m.pathState.validity != pathValid {
+		t.Errorf("cycled dir under DirArgument should classify pathValid; got %d", m.pathState.validity)
+	}
+	if m.renderedInput() == m.input.View() {
+		t.Errorf("overlay should apply during dir cycling, but renderedInput matches raw input.View")
+	}
+
+	// Forward-Tab to the next dir candidate. Validity stays pathValid (both
+	// are real dirs under DirArgument) — but the cycled value differs, so
+	// the rendered output must differ between the two cycle states.
+	firstCycleRender := m.renderedInput()
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab})
+	if m.renderedInput() == firstCycleRender {
+		t.Errorf("cycling to second dir candidate should change the rendered overlay coverage")
+	}
+}
+
+// TestRender_OverlayRefreshesOnCycleRevert exercises the wrap-to-original
+// path: with two candidates, three forward Tabs cycle index 0 → 1 → -1
+// (revert to completionHolder). After revert, pathState must reflect the
+// ORIGINAL input — not the last-cycled candidate — because the
+// input-changed branch later in Update won't fire (lastInput == restored
+// value).
+func TestRender_OverlayRefreshesOnCycleRevert(t *testing.T) {
+	dir := t.TempDir()
+	mustMkdir(t, filepath.Join(dir, "doc1"))
+	mustMkdir(t, filepath.Join(dir, "doc2"))
+
+	m, err := New(pathTestCommands(), 500, WithFilesystemCompletions(true))
+	if err != nil {
+		t.Fatal(err)
+	}
+	original := "cd " + filepath.Join(dir, "doc")
+	m = simulateTyping(t, m, original)
+	if !m.pathState.active {
+		t.Fatal("setup: expected active pathState for partial dir match")
+	}
+	// Capture the *original* partial-state offsets so we can compare them
+	// after the revert. The original token is "doc" (3 chars), base "doc".
+	origValueStart := m.pathState.valueStart
+	origValueEnd := m.pathState.valueEnd
+	origBase := m.pathState.base
+	if m.pathState.validity != pathPartial {
+		t.Fatalf("setup: expected pathPartial for original, got %d", m.pathState.validity)
+	}
+
+	// Three Tabs: 0, 1, revert.
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab}) // index 0
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab}) // index 1
+	m, _ = m.Update(tea.KeyPressMsg{Code: tea.KeyTab}) // wraps to -1, revert to original
+
+	if m.input.Value() != original {
+		t.Fatalf("after wrap-to-revert: input %q, want original %q", m.input.Value(), original)
+	}
+	if m.completionHolder != "" {
+		t.Errorf("after revert: completionHolder should be cleared, got %q", m.completionHolder)
+	}
+	if !m.pathState.active {
+		t.Fatal("pathState should be active after revert (matches original partial state)")
+	}
+	if m.pathState.validity != pathPartial {
+		t.Errorf("after revert: validity should reflect original partial state, got %d", m.pathState.validity)
+	}
+	if m.pathState.valueStart != origValueStart || m.pathState.valueEnd != origValueEnd {
+		t.Errorf("after revert: offsets %d..%d, want original %d..%d (offsets should track restored value)",
+			m.pathState.valueStart, m.pathState.valueEnd, origValueStart, origValueEnd)
+	}
+	if m.pathState.base != origBase {
+		t.Errorf("after revert: base %q, want original %q", m.pathState.base, origBase)
 	}
 }
 

--- a/path_integration_test.go
+++ b/path_integration_test.go
@@ -8,8 +8,8 @@ import (
 )
 
 // pathTestCommands constructs a minimal set of test commands tailored to
-// exercising the Phase 3 Update integration without depending on the
-// project-wide TestCommands fixture.
+// exercising the path-completion Update integration without depending on
+// the project-wide TestCommands fixture.
 func pathTestCommands() []*Command {
 	return []*Command{
 		{
@@ -167,9 +167,10 @@ func TestResetModelClearsPathState(t *testing.T) {
 	}
 }
 
-// TestTabAccept_EqualsFormRegressionGuard locks in the v4 regression: the
-// Phase 3 wiring must not drop the "--path=" prefix when Tab-accepting a
-// path completion. This exercises the full Update flow with simulateTyping.
+// TestTabAccept_EqualsFormRegressionGuard locks in the regression where
+// the recompute → completion wiring previously dropped the "--path="
+// prefix when Tab-accepting a path completion. Drives the full Update
+// flow with simulateTyping.
 func TestTabAccept_EqualsFormRegressionGuard(t *testing.T) {
 	dir := t.TempDir()
 	mustWriteFile(t, filepath.Join(dir, "report.txt"))

--- a/pathcache.go
+++ b/pathcache.go
@@ -75,6 +75,19 @@ type dirCacheEntry struct {
 	err error
 }
 
+// matchKey returns the (names slice, lookup needle) pair to use for
+// case-aware matching of base against this entry. On case-insensitive
+// platforms (macOS, Windows heuristic) it returns the folded names and a
+// lowercased base; on Linux it returns the raw names and base unchanged.
+// Consumers iterate the returned slice in parallel with entry.names by
+// index — names is always the source of truth for display.
+func (e *dirCacheEntry) matchKey(base string) (names []string, needle string) {
+	if caseInsensitiveFS() {
+		return e.foldNames, strings.ToLower(base)
+	}
+	return e.names, base
+}
+
 // dirCache is a bounded LRU + TTL cache of [os.ReadDir] results, keyed by
 // cleaned absolute parent path.
 //

--- a/pathcache.go
+++ b/pathcache.go
@@ -1,0 +1,179 @@
+package bubblecomplete
+
+import (
+	"io/fs"
+	"os"
+	"strings"
+	"sync"
+	"time"
+)
+
+// entryKind classifies a directory entry by file type. Captured up-front by
+// the cache so the classifier and candidate generator can route entries
+// without re-statting. kindSymlink and kindUnknown are left unresolved here;
+// the candidate generator resolves target kinds lazily for survivors that
+// need it.
+type entryKind uint8
+
+const (
+	// kindOther covers anything that's neither file, dir, nor symlink —
+	// devices, sockets, pipes, irregular. Excluded from candidates by
+	// generateCandidates regardless of ArgumentType.
+	kindOther entryKind = iota
+	kindFile
+	kindDir
+	kindSymlink
+	// kindUnknown means the OS did not report a type (DT_UNKNOWN sentinel
+	// leaked through Go's lstat fallback, or a custom fs.FS DirEntry that
+	// doesn't follow os.ReadDir's resolution contract). Treated like a
+	// symlink: candidate generation resolves via os.Stat within the budget.
+	kindUnknown
+)
+
+// kindFromDirEntry maps an [fs.DirEntry]'s Type() to an [entryKind].
+//
+// os.ReadDir resolves DT_UNKNOWN entries by calling lstat, so under standard
+// use a mode with no type bits set (Type() == 0) means "regular file". The
+// ^FileMode(0) sentinel guard catches custom DirEntry implementations that
+// return the unresolved value. Devices, sockets, pipes, and other irregular
+// modes fall into kindOther and are filtered out of candidates.
+func kindFromDirEntry(d fs.DirEntry) entryKind {
+	mode := d.Type()
+	if mode == ^fs.FileMode(0) {
+		return kindUnknown
+	}
+	switch {
+	case mode.IsDir():
+		return kindDir
+	case mode&fs.ModeSymlink != 0:
+		return kindSymlink
+	case mode == 0:
+		// No type bits set after the readdir+lstat fallback → regular file.
+		return kindFile
+	default:
+		return kindOther
+	}
+}
+
+// dirCacheEntry holds one cached ReadDir result. Slices are read-only by
+// contract; consumers must not mutate them.
+type dirCacheEntry struct {
+	// names, foldNames, and kinds are parallel slices indexed by entry
+	// position. names holds the raw filesystem case; foldNames is the
+	// lowercase form for case-insensitive matching; kinds is the type as
+	// reported by [fs.DirEntry.Type] at read time.
+	names     []string
+	foldNames []string
+	kinds     []entryKind
+
+	// fetchedAt is when the entry was populated; used for TTL eviction.
+	fetchedAt time.Time
+
+	// err is the ReadDir error, if any. Sticky for the TTL window so
+	// repeated keystrokes on a missing or permission-denied directory
+	// don't trigger retry storms.
+	err error
+}
+
+// dirCache is a bounded LRU + TTL cache of [os.ReadDir] results, keyed by
+// cleaned absolute parent path.
+//
+// The mutex makes the cache safe under future tea.Cmd async paths. Production
+// callers run on Bubble Tea's single Update goroutine where it's
+// uncontended.
+type dirCache struct {
+	mu      sync.Mutex
+	entries map[string]*dirCacheEntry
+	order   []string // LRU order: front (index 0) is most-recently-used
+	maxDirs int
+	ttl     time.Duration
+}
+
+const (
+	// defaultDirCacheMaxDirs caps how many parent directories are kept in
+	// memory. 64 is far more than a typical session needs.
+	defaultDirCacheMaxDirs = 64
+	// defaultDirCacheTTL is how long a cached entry stays valid before
+	// re-fetch. Short enough that filesystem changes surface within a
+	// reasonable time; long enough that a typing burst hits cache.
+	defaultDirCacheTTL = 2 * time.Second
+)
+
+// newDirCache constructs a cache with library defaults.
+func newDirCache() *dirCache {
+	return &dirCache{
+		entries: make(map[string]*dirCacheEntry),
+		maxDirs: defaultDirCacheMaxDirs,
+		ttl:     defaultDirCacheTTL,
+	}
+}
+
+// read returns the cached entry for parent, refreshing if missing or stale.
+// An empty parent yields a synthetic empty entry — callers don't need to
+// special-case it.
+func (c *dirCache) read(parent string) *dirCacheEntry {
+	if parent == "" {
+		return &dirCacheEntry{}
+	}
+	c.mu.Lock()
+	defer c.mu.Unlock()
+
+	if e, ok := c.entries[parent]; ok {
+		if time.Since(e.fetchedAt) < c.ttl {
+			c.touchLocked(parent)
+			return e
+		}
+		// stale — fall through to refresh
+	}
+
+	entry := fetchDir(parent)
+	c.entries[parent] = entry
+	c.touchLocked(parent)
+	c.evictIfFullLocked()
+	return entry
+}
+
+// fetchDir performs an [os.ReadDir] and packages the result into a
+// [dirCacheEntry]. Errors are captured into entry.err; callers check it.
+//
+// Note: os.ReadDir is unbounded — it reads every entry in the directory and
+// returns them sorted. The TTL cache amortises the cost across keystrokes.
+func fetchDir(parent string) *dirCacheEntry {
+	e := &dirCacheEntry{fetchedAt: time.Now()}
+	entries, err := os.ReadDir(parent)
+	if err != nil {
+		e.err = err
+		return e
+	}
+	e.names = make([]string, len(entries))
+	e.foldNames = make([]string, len(entries))
+	e.kinds = make([]entryKind, len(entries))
+	for i, de := range entries {
+		name := de.Name()
+		e.names[i] = name
+		e.foldNames[i] = strings.ToLower(name)
+		e.kinds[i] = kindFromDirEntry(de)
+	}
+	return e
+}
+
+// touchLocked moves parent to the front of the LRU order. Caller holds c.mu.
+func (c *dirCache) touchLocked(parent string) {
+	for i, p := range c.order {
+		if p == parent {
+			c.order = append(c.order[:i], c.order[i+1:]...)
+			break
+		}
+	}
+	c.order = append([]string{parent}, c.order...)
+}
+
+// evictIfFullLocked drops least-recently-used entries until the cache is
+// within maxDirs. Caller holds c.mu.
+func (c *dirCache) evictIfFullLocked() {
+	for len(c.order) > c.maxDirs {
+		victim := c.order[len(c.order)-1]
+		c.order = c.order[:len(c.order)-1]
+		delete(c.entries, victim)
+	}
+}

--- a/pathcache_test.go
+++ b/pathcache_test.go
@@ -1,0 +1,175 @@
+package bubblecomplete
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+	"testing"
+	"time"
+)
+
+func TestDirCache_ReadsAndCaches(t *testing.T) {
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "a.txt"))
+	mustWriteFile(t, filepath.Join(dir, "b.txt"))
+	mustMkdir(t, filepath.Join(dir, "sub"))
+
+	c := newDirCache()
+	e := c.read(dir)
+	if e.err != nil {
+		t.Fatalf("read: %v", e.err)
+	}
+	if len(e.names) != 3 {
+		t.Fatalf("expected 3 entries, got %d", len(e.names))
+	}
+	wantKinds := map[string]entryKind{"a.txt": kindFile, "b.txt": kindFile, "sub": kindDir}
+	for i, n := range e.names {
+		if e.kinds[i] != wantKinds[n] {
+			t.Errorf("%s: kind = %d, want %d", n, e.kinds[i], wantKinds[n])
+		}
+	}
+
+	// Second read within TTL must reuse the same entry pointer.
+	e2 := c.read(dir)
+	if e2 != e {
+		t.Errorf("second read returned a different entry pointer (TTL miss?)")
+	}
+}
+
+func TestDirCache_EmptyParentReturnsEmpty(t *testing.T) {
+	c := newDirCache()
+	e := c.read("")
+	if e == nil {
+		t.Fatal("read(\"\") returned nil")
+	}
+	if e.err != nil {
+		t.Errorf("empty-parent err = %v, want nil", e.err)
+	}
+	if len(e.names) != 0 {
+		t.Errorf("empty-parent names = %v, want empty", e.names)
+	}
+}
+
+func TestDirCache_StickyError(t *testing.T) {
+	c := newDirCache()
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	e1 := c.read(missing)
+	if e1.err == nil {
+		t.Fatal("expected error reading missing dir")
+	}
+
+	// Create the dir AFTER the first read. Within TTL the cached error
+	// should still be returned — no retry storm.
+	if err := os.Mkdir(missing, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	e2 := c.read(missing)
+	if e2.err == nil {
+		t.Error("expected cached error to stick within TTL")
+	}
+}
+
+func TestDirCache_TTLRefresh(t *testing.T) {
+	dir := t.TempDir()
+	c := newDirCache()
+	c.ttl = 1 * time.Millisecond
+
+	e1 := c.read(dir)
+	if e1.err != nil {
+		t.Fatal(e1.err)
+	}
+
+	// Wait past the TTL, then re-read — should produce a fresh entry.
+	time.Sleep(5 * time.Millisecond)
+	e2 := c.read(dir)
+	if e2 == e1 {
+		t.Errorf("expected fresh entry after TTL, got same pointer")
+	}
+}
+
+func TestDirCache_LRUEviction(t *testing.T) {
+	c := newDirCache()
+	c.maxDirs = 3
+
+	// Populate four distinct dirs.
+	dirs := make([]string, 4)
+	for i := range 4 {
+		dirs[i] = t.TempDir()
+		c.read(dirs[i])
+	}
+
+	// The first one inserted (dirs[0]) was least-recently-used → evicted.
+	if _, ok := c.entries[dirs[0]]; ok {
+		t.Errorf("dirs[0] should have been evicted")
+	}
+	for i := 1; i < 4; i++ {
+		if _, ok := c.entries[dirs[i]]; !ok {
+			t.Errorf("dirs[%d] missing from cache", i)
+		}
+	}
+}
+
+func TestDirCache_LRUTouchOrder(t *testing.T) {
+	c := newDirCache()
+	c.maxDirs = 3
+
+	a := t.TempDir()
+	b := t.TempDir()
+	cdir := t.TempDir()
+	d := t.TempDir()
+
+	c.read(a)
+	c.read(b)
+	c.read(cdir)
+	// Touch a so it's most-recently-used.
+	c.read(a)
+	// Insert d — least-recently-used (now b) should be evicted.
+	c.read(d)
+
+	if _, ok := c.entries[b]; ok {
+		t.Errorf("b should have been evicted as LRU")
+	}
+	if _, ok := c.entries[a]; !ok {
+		t.Errorf("a should remain after touch")
+	}
+}
+
+func TestDirCache_ConcurrentReads(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("temp dir cleanup races on windows under -race; covered by other tests")
+	}
+	dir := t.TempDir()
+	for i := range 5 {
+		mustWriteFile(t, filepath.Join(dir, fmt.Sprintf("f%d.txt", i)))
+	}
+	c := newDirCache()
+
+	var wg sync.WaitGroup
+	for range 20 {
+		wg.Go(func() {
+			for range 20 {
+				e := c.read(dir)
+				if e.err != nil {
+					t.Errorf("concurrent read: %v", e.err)
+				}
+			}
+		})
+	}
+	wg.Wait()
+}
+
+func mustWriteFile(t *testing.T, path string) {
+	t.Helper()
+	if err := os.WriteFile(path, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func mustMkdir(t *testing.T, path string) {
+	t.Helper()
+	if err := os.Mkdir(path, 0o755); err != nil {
+		t.Fatal(err)
+	}
+}

--- a/pathcomplete.go
+++ b/pathcomplete.go
@@ -27,10 +27,14 @@ const (
 
 // pathState is the per-keystroke result of [activeFileArgument] plus
 // classification and candidate generation. Stored on [Model], read by
-// [Model.Render] and the validation-style suppression. Frozen during
-// completion cycling, same as validationErr — [Model.renderedInput]
-// bypasses the overlay during cycling so the stale offsets don't mis-style
-// the previewed candidate.
+// [Model.Render] and the validation-style suppression.
+//
+// Refreshed on every input change (the input-changed branch in Update)
+// AND on every Tab cycle and cycle-revert (keyTab), so the offsets and
+// validity always reflect the value currently in [Model.input]. Files
+// cycled-to carry a trailing space which makes activeFileArgument
+// inactive — overlay correctly absent for that preview. Dirs cycle with
+// the overlay active and the colour reflects the cycled-to dir.
 type pathState struct {
 	// active is true when the user is currently editing a value for a
 	// file/dir-typed argument and the feature is enabled.
@@ -65,7 +69,7 @@ type pathState struct {
 type pathCompletion struct {
 	displayName string // basename + "/" if directory
 	insertion   string // FULL active-token replacement
-	description string // "file" or "dir"
+	description string // "file" / "dir" — or "symlink → file" / "symlink → dir" when the underlying DirEntry was a symlink
 	isDir       bool
 }
 
@@ -96,6 +100,28 @@ func statBudget(limit int) int {
 	return limit
 }
 
+// activeArg describes the user's active typing position when it's a value
+// for a file/dir-typed argument. Populated by [activeFileArgument] and
+// consumed by [Model.recomputePathState].
+type activeArg struct {
+	// kind is one of FileArgument, DirArgument, FileDirArgument.
+	kind ArgumentType
+	// name is the active argument's display name as produced by
+	// argument.getName(). Used by isPartialPathMidType to verify that a
+	// PathNotFound validation error belongs to this argument before
+	// suppressing whole-input red.
+	name string
+	// valueStart and valueEnd are byte offsets in the input string that
+	// bound the *unquoted* value text — used by the render overlay.
+	valueStart int
+	valueEnd   int
+	// tokenPrefix is the leading bytes of the active token before the
+	// value: flag prefix (`--path=`) and/or opening quote.
+	tokenPrefix string
+	// openingQuote is 0 if no quote, else '"' or '\''.
+	openingQuote rune
+}
+
 // activeFileArgument reports whether the user is currently editing a value
 // for a [FileArgument], [DirArgument], or [FileDirArgument], and if so
 // returns the metadata needed to drive completion and validity colouring.
@@ -106,41 +132,27 @@ func statBudget(limit int) int {
 //   - the active position is a command word, a flag name without value, or a
 //     value for a non-file argument type
 //   - the active value is empty (e.g. "--path=" with nothing after)
-//
-// argName is the active argument's display name (argument.getName()) — used
-// to verify that a PathNotFound validation error belongs to the active
-// token before suppressing whole-input red. valueStart and valueEnd are
-// byte offsets in input that bound the *unquoted* value text. tokenPrefix
-// is whatever leads the active token before the value (flag prefix and/or
-// opening quote). openingQuote is 0 if no quote.
-func activeFileArgument(input string, commands []*Command) (
-	kind ArgumentType,
-	argName string,
-	valueStart, valueEnd int,
-	tokenPrefix string,
-	openingQuote rune,
-	ok bool,
-) {
+func activeFileArgument(input string, commands []*Command) (activeArg, bool) {
 	if strings.HasSuffix(input, " ") {
-		return
+		return activeArg{}, false
 	}
 	tokens := tokenize(input)
 	if len(tokens) == 0 {
-		return
+		return activeArg{}, false
 	}
 	parts := splitInput(input)
 	if len(parts) == 0 {
-		return
+		return activeArg{}, false
 	}
 
 	finalCmd, depth, globalFlags := walkToFinalCommand(input, parts, commands)
 	if finalCmd == nil {
-		return
+		return activeArg{}, false
 	}
 
 	argParts := parts[depth:]
 	if len(argParts) == 0 {
-		return
+		return activeArg{}, false
 	}
 	posArgs, flagArgs := splitPositionArgsAndFlags(argParts, finalCmd, globalFlags)
 
@@ -157,43 +169,21 @@ func activeFileArgument(input string, commands []*Command) (
 				continue
 			}
 			if !isFileLikeArg(f.Type) {
-				return
+				return activeArg{}, false
 			}
-			kind = f.Type
-			argName = f.getName()
-			eqIdx := strings.IndexByte(tokenRaw, '=')
-			valueStart = activeToken.Start + eqIdx + 1
-			valueEnd = activeToken.End
-			tokenPrefix = tokenRaw[:eqIdx+1]
-			// Inline opening quote after '='?
-			if valueStart < valueEnd {
-				first := input[valueStart]
-				if first == '"' || first == '\'' {
-					openingQuote = rune(first)
-					tokenPrefix += string(openingQuote)
-					valueStart++
-					if valueEnd > valueStart && input[valueEnd-1] == first {
-						valueEnd--
-					}
-				}
-			}
-			ok = valueStart < valueEnd
-			if !ok {
-				return ArgumentType(""), "", 0, 0, "", 0, false
-			}
-			return kind, argName, valueStart, valueEnd, tokenPrefix, openingQuote, true
+			return equalsFormActiveArg(input, activeToken, tokenRaw, f.Type, f.getName())
 		}
 		// Flag prefix didn't match any known flag — not active.
-		return
+		return activeArg{}, false
 	}
 
 	// Case 2: space-separated flag value. isEnteringFlagValue inspects the
 	// PRECEDING token to see whether it was a flag waiting for a value.
 	if yes, flag := isEnteringFlagValue(input, finalCmd, flagArgs, globalFlags); yes {
 		if !isFileLikeArg(flag.Type) {
-			return
+			return activeArg{}, false
 		}
-		return finalizeTokenRange(activeToken, flag.Type, flag.getName())
+		return tokenActiveArg(activeToken, flag.Type, flag.getName())
 	}
 
 	// Case 3: positional argument value. Two guards:
@@ -207,38 +197,67 @@ func activeFileArgument(input string, commands []*Command) (
 		len(posArgs) > 0 && len(posArgs) <= len(finalCmd.PositionalArguments) {
 		if yes, pos := isEnteringPosArgValue(input, finalCmd, posArgs); yes {
 			if !isFileLikeArg(pos.Type) {
-				return
+				return activeArg{}, false
 			}
-			return finalizeTokenRange(activeToken, pos.Type, pos.getName())
+			return tokenActiveArg(activeToken, pos.Type, pos.getName())
 		}
 	}
 
-	return
+	return activeArg{}, false
 }
 
-// finalizeTokenRange computes valueStart/valueEnd/tokenPrefix/openingQuote
-// for a positional or space-separated-flag value (Case 2/3 above). The
-// active token's bounds come from [tokenize]; quote handling reflects
-// whether the token opened with a quote and whether that quote was closed.
-func finalizeTokenRange(tok token, kind ArgumentType, name string) (
-	ArgumentType, string, int, int, string, rune, bool,
-) {
-	valueStart := tok.Start
-	valueEnd := tok.End
-	var tokenPrefix string
-	var openingQuote rune
-	if tok.Quoted {
-		openingQuote = tok.Quote
-		tokenPrefix = string(openingQuote)
-		valueStart++
-		if tok.Closed {
-			valueEnd--
+// equalsFormActiveArg builds an activeArg for the equals-form flag value
+// case (`--flag=value`, `--flag="value"`, etc.). Splits the active token on
+// the first '=' and detects an inline opener after it.
+func equalsFormActiveArg(input string, tok token, tokenRaw string, kind ArgumentType, name string) (activeArg, bool) {
+	eqIdx := strings.IndexByte(tokenRaw, '=')
+	a := activeArg{
+		kind:        kind,
+		name:        name,
+		valueStart:  tok.Start + eqIdx + 1,
+		valueEnd:    tok.End,
+		tokenPrefix: tokenRaw[:eqIdx+1],
+	}
+	if a.valueStart < a.valueEnd {
+		first := input[a.valueStart]
+		if first == '"' || first == '\'' {
+			a.openingQuote = rune(first)
+			a.tokenPrefix += string(a.openingQuote)
+			a.valueStart++
+			if a.valueEnd > a.valueStart && input[a.valueEnd-1] == first {
+				a.valueEnd--
+			}
 		}
 	}
-	if valueStart >= valueEnd {
-		return ArgumentType(""), "", 0, 0, "", 0, false
+	if a.valueStart >= a.valueEnd {
+		return activeArg{}, false
 	}
-	return kind, name, valueStart, valueEnd, tokenPrefix, openingQuote, true
+	return a, true
+}
+
+// tokenActiveArg builds an activeArg for a positional or space-separated
+// flag value (Cases 2 and 3 above). The active token's bounds come from
+// [tokenize]; quote handling reflects whether the token opened with a
+// quote and whether that quote was closed.
+func tokenActiveArg(tok token, kind ArgumentType, name string) (activeArg, bool) {
+	a := activeArg{
+		kind:       kind,
+		name:       name,
+		valueStart: tok.Start,
+		valueEnd:   tok.End,
+	}
+	if tok.Quoted {
+		a.openingQuote = tok.Quote
+		a.tokenPrefix = string(a.openingQuote)
+		a.valueStart++
+		if tok.Closed {
+			a.valueEnd--
+		}
+	}
+	if a.valueStart >= a.valueEnd {
+		return activeArg{}, false
+	}
+	return a, true
 }
 
 // isFileLikeArg reports whether t is one of the filesystem-backed argument
@@ -307,28 +326,53 @@ func classifyByKind(kind ArgumentType, isDir bool) pathValidity {
 }
 
 func exactMatch(entry *dirCacheEntry, base string) bool {
-	if caseInsensitiveFS() {
-		return slices.Contains(entry.foldNames, strings.ToLower(base))
-	}
-	return slices.Contains(entry.names, base)
+	names, needle := entry.matchKey(base)
+	return slices.Contains(names, needle)
 }
 
 func prefixMatch(entry *dirCacheEntry, base string) bool {
-	if caseInsensitiveFS() {
-		lower := strings.ToLower(base)
-		for _, n := range entry.foldNames {
-			if strings.HasPrefix(n, lower) {
-				return true
-			}
-		}
-		return false
-	}
-	for _, n := range entry.names {
-		if strings.HasPrefix(n, base) {
+	names, needle := entry.matchKey(base)
+	for _, n := range names {
+		if strings.HasPrefix(n, needle) {
 			return true
 		}
 	}
 	return false
+}
+
+// candidateRequest groups the inputs to [generateCandidates] so the
+// function signature stays manageable. Callers should construct the
+// struct deliberately rather than relying on field defaults — several
+// fields have meaningful zero values (e.g. an empty tokenPrefix or
+// userPrefix, openingQuote == 0 meaning "no quote", hiddenFiles ==
+// false), so a partial literal must be intentional, not accidental.
+type candidateRequest struct {
+	// kind is the active argument's type (FileArgument / DirArgument /
+	// FileDirArgument) — drives the inclusion filter.
+	kind ArgumentType
+	// tokenPrefix is the leading bytes of the active token that precede
+	// the value (flag prefix and/or opening quote). Used to build
+	// insertion strings that preserve the user's token shape.
+	tokenPrefix string
+	// userPrefix is the leading bytes of the typed value up to the last
+	// separator before base ("~/", "./", "/abs/path/", ""). Preserved
+	// verbatim in insertions so completion keeps the user's style.
+	userPrefix string
+	// openingQuote is 0 if no quote, else '"' or '\'' — drives insertion
+	// quoting and auto-quote-on-space logic in [buildCompletion].
+	openingQuote rune
+	// base is the basename prefix to match against. Empty when the typed
+	// value ends in a separator (list-all-children case).
+	base string
+	// entry is the parent directory's cached ReadDir result.
+	entry *dirCacheEntry
+	// limit caps the candidate count after sort. Clamped to >= 1.
+	limit int
+	// hiddenFiles surfaces dotfiles even when base does not start with ".".
+	hiddenFiles bool
+	// parent is the absolute parent directory. Used to construct stat
+	// paths when resolving symlink/unknown entry kinds.
+	parent string
 }
 
 // generateCandidates produces the [pathCompletion] list for the active
@@ -338,22 +382,11 @@ func prefixMatch(entry *dirCacheEntry, base string) bool {
 // Symlink target kinds are resolved via [os.Stat] for entries that survive
 // the prefix and hidden filters; [statBudget] bounds the worst-case stat
 // count per pass.
-func generateCandidates(
-	kind ArgumentType,
-	tokenPrefix, userPrefix string,
-	openingQuote rune,
-	base string,
-	entry *dirCacheEntry,
-	limit int,
-	hiddenFiles bool,
-	parent string,
-) []pathCompletion {
-	if entry.err != nil {
+func generateCandidates(req candidateRequest) []pathCompletion {
+	if req.entry.err != nil {
 		return nil
 	}
-	if limit < 1 {
-		limit = 1
-	}
+	limit := max(req.limit, 1)
 
 	type prelim struct {
 		name      string
@@ -361,27 +394,29 @@ func generateCandidates(
 		isSymlink bool // original DirEntry kind was kindSymlink (description hint)
 	}
 
-	caseInsensitive := caseInsensitiveFS()
-	lowerBase := strings.ToLower(base)
+	matchNames, needle := req.entry.matchKey(req.base)
 	statsRemaining := statBudget(limit)
-	survivors := make([]prelim, 0, min(limit, len(entry.names)))
+	survivors := make([]prelim, 0, min(limit, len(req.entry.names)))
 
-	for i, name := range entry.names {
-		if !matchesPrefix(name, entry.foldNames[i], base, lowerBase, caseInsensitive) {
+	for i, candidateKey := range matchNames {
+		if !strings.HasPrefix(candidateKey, needle) {
 			continue
 		}
-		if !hiddenFiles && strings.HasPrefix(name, ".") && !strings.HasPrefix(base, ".") {
+		// Display always uses the raw filesystem name regardless of
+		// case-insensitive matching — case is preserved in the UI.
+		name := req.entry.names[i]
+		if !req.hiddenFiles && strings.HasPrefix(name, ".") && !strings.HasPrefix(req.base, ".") {
 			continue
 		}
 
-		k := entry.kinds[i]
+		k := req.entry.kinds[i]
 		wasSymlink := k == kindSymlink
 		if k == kindSymlink || k == kindUnknown {
 			if statsRemaining <= 0 {
 				continue // budget exhausted; drop
 			}
 			statsRemaining--
-			info, err := os.Stat(filepath.Join(parent, name))
+			info, err := os.Stat(filepath.Join(req.parent, name))
 			if err != nil {
 				continue // broken symlink or stat failure
 			}
@@ -395,7 +430,7 @@ func generateCandidates(
 			}
 		}
 
-		if !includeKind(kind, k) {
+		if !includeKind(req.kind, k) {
 			continue
 		}
 		survivors = append(survivors, prelim{name: name, isDir: k == kindDir, isSymlink: wasSymlink})
@@ -415,17 +450,9 @@ func generateCandidates(
 
 	out := make([]pathCompletion, len(survivors))
 	for i, s := range survivors {
-		out[i] = buildCompletion(s.name, s.isDir, s.isSymlink, tokenPrefix, userPrefix, openingQuote)
+		out[i] = buildCompletion(s.name, s.isDir, s.isSymlink, req.tokenPrefix, req.userPrefix, req.openingQuote)
 	}
 	return out
-}
-
-// matchesPrefix applies the platform's case-sensitivity heuristic.
-func matchesPrefix(name, foldName, base, lowerBase string, caseInsensitive bool) bool {
-	if caseInsensitive {
-		return strings.HasPrefix(foldName, lowerBase)
-	}
-	return strings.HasPrefix(name, base)
 }
 
 // includeKind applies the candidate-inclusion table:
@@ -549,7 +576,7 @@ func (m *Model) recomputePathState() {
 		return
 	}
 
-	kind, argName, valueStart, valueEnd, tokenPrefix, openingQuote, ok := activeFileArgument(m.input.Value(), m.Commands)
+	a, ok := activeFileArgument(m.input.Value(), m.Commands)
 	if !ok {
 		return
 	}
@@ -560,8 +587,8 @@ func (m *Model) recomputePathState() {
 
 	cwd, _ := os.Getwd()
 	home, _ := os.UserHomeDir()
-	typed := m.input.Value()[valueStart:valueEnd]
-	expandTilde := openingQuote != '\''
+	typed := m.input.Value()[a.valueStart:a.valueEnd]
+	expandTilde := a.openingQuote != '\''
 	fullClean, parent, base, userPrefix := resolvePath(typed, cwd, home, expandTilde)
 
 	entries := m.pathCache.read(parent)
@@ -570,12 +597,22 @@ func (m *Model) recomputePathState() {
 
 	m.pathState = pathState{
 		active:     true,
-		kind:       kind,
-		argName:    argName,
-		valueStart: valueStart,
-		valueEnd:   valueEnd,
+		kind:       a.kind,
+		argName:    a.name,
+		valueStart: a.valueStart,
+		valueEnd:   a.valueEnd,
 		base:       base,
-		validity:   classify(kind, fullClean, base, entries),
-		candidates: generateCandidates(kind, tokenPrefix, userPrefix, openingQuote, base, entries, limit, m.HiddenFiles, parent),
+		validity:   classify(a.kind, fullClean, base, entries),
+		candidates: generateCandidates(candidateRequest{
+			kind:         a.kind,
+			tokenPrefix:  a.tokenPrefix,
+			userPrefix:   userPrefix,
+			openingQuote: a.openingQuote,
+			base:         base,
+			entry:        entries,
+			limit:        limit,
+			hiddenFiles:  m.HiddenFiles,
+			parent:       parent,
+		}),
 	}
 }

--- a/pathcomplete.go
+++ b/pathcomplete.go
@@ -1,6 +1,7 @@
 package bubblecomplete
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"runtime"
@@ -27,7 +28,9 @@ const (
 // pathState is the per-keystroke result of [activeFileArgument] plus
 // classification and candidate generation. Stored on [Model], read by
 // [Model.Render] and the validation-style suppression. Frozen during
-// completion cycling, same as validationErr.
+// completion cycling, same as validationErr — [Model.renderedInput]
+// bypasses the overlay during cycling so the stale offsets don't mis-style
+// the previewed candidate.
 type pathState struct {
 	// active is true when the user is currently editing a value for a
 	// file/dir-typed argument and the feature is enabled.
@@ -35,6 +38,11 @@ type pathState struct {
 	// kind is the argument's [ArgumentType] (one of FileArgument,
 	// DirArgument, FileDirArgument) when active.
 	kind ArgumentType
+	// argName is the active argument's display name as produced by
+	// argument.getName() — used to verify that a PathNotFound validation
+	// error actually belongs to the active token before suppressing
+	// whole-input red.
+	argName string
 	// valueStart and valueEnd are byte offsets in m.input.Value() of the
 	// unquoted value range — used by the render overlay.
 	valueStart int
@@ -99,11 +107,15 @@ func statBudget(limit int) int {
 //     value for a non-file argument type
 //   - the active value is empty (e.g. "--path=" with nothing after)
 //
-// valueStart and valueEnd are byte offsets in input that bound the *unquoted*
-// value text. tokenPrefix is whatever leads the active token before the
-// value (flag prefix and/or opening quote). openingQuote is 0 if no quote.
+// argName is the active argument's display name (argument.getName()) — used
+// to verify that a PathNotFound validation error belongs to the active
+// token before suppressing whole-input red. valueStart and valueEnd are
+// byte offsets in input that bound the *unquoted* value text. tokenPrefix
+// is whatever leads the active token before the value (flag prefix and/or
+// opening quote). openingQuote is 0 if no quote.
 func activeFileArgument(input string, commands []*Command) (
 	kind ArgumentType,
+	argName string,
 	valueStart, valueEnd int,
 	tokenPrefix string,
 	openingQuote rune,
@@ -148,6 +160,7 @@ func activeFileArgument(input string, commands []*Command) (
 				return
 			}
 			kind = f.Type
+			argName = f.getName()
 			eqIdx := strings.IndexByte(tokenRaw, '=')
 			valueStart = activeToken.Start + eqIdx + 1
 			valueEnd = activeToken.End
@@ -166,9 +179,9 @@ func activeFileArgument(input string, commands []*Command) (
 			}
 			ok = valueStart < valueEnd
 			if !ok {
-				return ArgumentType(""), 0, 0, "", 0, false
+				return ArgumentType(""), "", 0, 0, "", 0, false
 			}
-			return kind, valueStart, valueEnd, tokenPrefix, openingQuote, true
+			return kind, argName, valueStart, valueEnd, tokenPrefix, openingQuote, true
 		}
 		// Flag prefix didn't match any known flag — not active.
 		return
@@ -180,7 +193,7 @@ func activeFileArgument(input string, commands []*Command) (
 		if !isFileLikeArg(flag.Type) {
 			return
 		}
-		return finalizeTokenRange(activeToken, flag.Type)
+		return finalizeTokenRange(activeToken, flag.Type, flag.getName())
 	}
 
 	// Case 3: positional argument value. Two guards:
@@ -196,7 +209,7 @@ func activeFileArgument(input string, commands []*Command) (
 			if !isFileLikeArg(pos.Type) {
 				return
 			}
-			return finalizeTokenRange(activeToken, pos.Type)
+			return finalizeTokenRange(activeToken, pos.Type, pos.getName())
 		}
 	}
 
@@ -207,8 +220,8 @@ func activeFileArgument(input string, commands []*Command) (
 // for a positional or space-separated-flag value (Case 2/3 above). The
 // active token's bounds come from [tokenize]; quote handling reflects
 // whether the token opened with a quote and whether that quote was closed.
-func finalizeTokenRange(tok token, kind ArgumentType) (
-	ArgumentType, int, int, string, rune, bool,
+func finalizeTokenRange(tok token, kind ArgumentType, name string) (
+	ArgumentType, string, int, int, string, rune, bool,
 ) {
 	valueStart := tok.Start
 	valueEnd := tok.End
@@ -223,9 +236,9 @@ func finalizeTokenRange(tok token, kind ArgumentType) (
 		}
 	}
 	if valueStart >= valueEnd {
-		return ArgumentType(""), 0, 0, "", 0, false
+		return ArgumentType(""), "", 0, 0, "", 0, false
 	}
-	return kind, valueStart, valueEnd, tokenPrefix, openingQuote, true
+	return kind, name, valueStart, valueEnd, tokenPrefix, openingQuote, true
 }
 
 // isFileLikeArg reports whether t is one of the filesystem-backed argument
@@ -478,6 +491,31 @@ func buildCompletion(name string, isDir bool, tokenPrefix, userPrefix string, op
 	}
 }
 
+// isPartialPathMidType reports whether the whole-input invalid style should
+// be suppressed in favour of the path-range overlay. True only when:
+//   - the active path is a strict prefix (pathPartial), AND
+//   - the validation error is a PathNotFound, AND
+//   - the error's Argument matches the active argument's name.
+//
+// The argument-name check matters for commands with multiple path
+// positionals: typing `cp /missing/foo /tmp/par` would otherwise suppress
+// the whole-input red even though the validation error comes from the
+// FIRST (committed) path, not the partial second one. Suppression should
+// only fire when the partial path IS the cause of the error.
+func (m Model) isPartialPathMidType() bool {
+	if !m.pathState.active || m.pathState.validity != pathPartial {
+		return false
+	}
+	var ve *ValidationError
+	if !errors.As(m.validationErr, &ve) {
+		return false
+	}
+	if ve.Kind != PathNotFound {
+		return false
+	}
+	return ve.Argument == m.pathState.argName
+}
+
 // recomputePathState refreshes m.pathState from the current input value.
 // Called from Update's input-changed branch before getCompletions and
 // validateInput, so getCompletions can wholesale-replace its result list
@@ -493,7 +531,7 @@ func (m *Model) recomputePathState() {
 		return
 	}
 
-	kind, valueStart, valueEnd, tokenPrefix, openingQuote, ok := activeFileArgument(m.input.Value(), m.Commands)
+	kind, argName, valueStart, valueEnd, tokenPrefix, openingQuote, ok := activeFileArgument(m.input.Value(), m.Commands)
 	if !ok {
 		return
 	}
@@ -515,6 +553,7 @@ func (m *Model) recomputePathState() {
 	m.pathState = pathState{
 		active:     true,
 		kind:       kind,
+		argName:    argName,
 		valueStart: valueStart,
 		valueEnd:   valueEnd,
 		base:       base,

--- a/pathcomplete.go
+++ b/pathcomplete.go
@@ -24,6 +24,31 @@ const (
 	pathValid
 )
 
+// pathState is the per-keystroke result of [activeFileArgument] plus
+// classification and candidate generation. Stored on [Model], read by
+// [Model.Render] and the validation-style suppression. Frozen during
+// completion cycling, same as validationErr.
+type pathState struct {
+	// active is true when the user is currently editing a value for a
+	// file/dir-typed argument and the feature is enabled.
+	active bool
+	// kind is the argument's [ArgumentType] (one of FileArgument,
+	// DirArgument, FileDirArgument) when active.
+	kind ArgumentType
+	// valueStart and valueEnd are byte offsets in m.input.Value() of the
+	// unquoted value range — used by the render overlay.
+	valueStart int
+	valueEnd   int
+	// base is the basename prefix from [resolvePath], used as the
+	// matchPrefix when path candidates replace the completion list.
+	base string
+	// validity drives the per-token overlay style.
+	validity pathValidity
+	// candidates is the list rendered in place of the normal completion
+	// rows when active and non-empty.
+	candidates []pathCompletion
+}
+
 // pathCompletion is a [completion] backed by a filesystem entry under the
 // active file/dir argument value. It carries the full active-token
 // replacement in insertion so the existing keyTab pretext + getAutocomplete
@@ -48,9 +73,13 @@ func (p pathCompletion) getAutocomplete() string { return p.insertion }
 // 100k symlinks. A floor protects the small-limit case from being
 // pathologically restrictive.
 //
-// The budget never changes observable output relative to an unbounded
-// stat — sort+truncate would have dropped the same alphabetically-late
-// entries anyway. It exists strictly to cap CPU on pathological cases.
+// The budget primarily exists to cap CPU on pathological cases. For the
+// typical mix of regular files and dirs (with DirEntry.Type() already
+// populated) it has no effect on output. For symlink-heavy directories
+// where dirs-first sorting would have promoted a late symlink-to-dir, the
+// budget can cause that entry to be dropped entirely rather than sorted
+// to the front — an accepted candidate-quality tradeoff against bounded
+// worst-case latency.
 func statBudget(limit int) int {
 	const floor = 16
 	if limit < floor {
@@ -446,5 +475,50 @@ func buildCompletion(name string, isDir bool, tokenPrefix, userPrefix string, op
 		insertion:   insertion,
 		description: description,
 		isDir:       isDir,
+	}
+}
+
+// recomputePathState refreshes m.pathState from the current input value.
+// Called from Update's input-changed branch before getCompletions and
+// validateInput, so getCompletions can wholesale-replace its result list
+// with pathState.candidates when the active argument is file/dir-typed.
+//
+// When the feature is disabled or no file/dir value is active, pathState is
+// reset to its zero value. Cost in that case is one bool check plus the
+// activeFileArgument detector (tokenisation + command walk, which run for
+// existing completion logic anyway).
+func (m *Model) recomputePathState() {
+	m.pathState = pathState{}
+	if !m.FilesystemCompletions {
+		return
+	}
+
+	kind, valueStart, valueEnd, tokenPrefix, openingQuote, ok := activeFileArgument(m.input.Value(), m.Commands)
+	if !ok {
+		return
+	}
+
+	if m.pathCache == nil {
+		m.pathCache = newDirCache()
+	}
+
+	cwd, _ := os.Getwd()
+	home, _ := os.UserHomeDir()
+	typed := m.input.Value()[valueStart:valueEnd]
+	expandTilde := openingQuote != '\''
+	fullClean, parent, base, userPrefix := resolvePath(typed, cwd, home, expandTilde)
+
+	entries := m.pathCache.read(parent)
+
+	limit := max(m.FilesystemCompletionLimit, 1)
+
+	m.pathState = pathState{
+		active:     true,
+		kind:       kind,
+		valueStart: valueStart,
+		valueEnd:   valueEnd,
+		base:       base,
+		validity:   classify(kind, fullClean, base, entries),
+		candidates: generateCandidates(kind, tokenPrefix, userPrefix, openingQuote, base, entries, limit, m.HiddenFiles, parent),
 	}
 }

--- a/pathcomplete.go
+++ b/pathcomplete.go
@@ -1,0 +1,450 @@
+package bubblecomplete
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"slices"
+	"sort"
+	"strings"
+)
+
+// pathValidity classifies the typed path value for the input-range overlay
+// and the whole-input style suppression.
+type pathValidity uint8
+
+const (
+	// pathInvalid: the value does not resolve, or resolves to the wrong kind.
+	pathInvalid pathValidity = iota
+	// pathPartial: the value is a strict prefix of one or more existing
+	// entries, OR (for FileArgument) the value ends in a separator on a
+	// real directory — mid-navigation.
+	pathPartial
+	// pathValid: the value resolves to an entry of the expected kind.
+	pathValid
+)
+
+// pathCompletion is a [completion] backed by a filesystem entry under the
+// active file/dir argument value. It carries the full active-token
+// replacement in insertion so the existing keyTab pretext + getAutocomplete
+// concatenation works unchanged for positional, space-separated flag, and
+// equals-form values.
+type pathCompletion struct {
+	displayName string // basename + "/" if directory
+	insertion   string // FULL active-token replacement
+	description string // "file" or "dir"
+	isDir       bool
+}
+
+func (p pathCompletion) getName() string         { return p.displayName }
+func (p pathCompletion) getDescription() string  { return p.description }
+func (p pathCompletion) getAutocomplete() string { return p.insertion }
+
+// statBudget returns the maximum number of [os.Stat] calls
+// generateCandidates will make per pass to resolve symlink / unknown-type
+// target kinds. Tying the budget to limit means worst-case CPU per
+// keystroke scales with the candidate cap the host configured: with the
+// default limit of 200, at most 200 stats are made even in a directory of
+// 100k symlinks. A floor protects the small-limit case from being
+// pathologically restrictive.
+//
+// The budget never changes observable output relative to an unbounded
+// stat — sort+truncate would have dropped the same alphabetically-late
+// entries anyway. It exists strictly to cap CPU on pathological cases.
+func statBudget(limit int) int {
+	const floor = 16
+	if limit < floor {
+		return floor
+	}
+	return limit
+}
+
+// activeFileArgument reports whether the user is currently editing a value
+// for a [FileArgument], [DirArgument], or [FileDirArgument], and if so
+// returns the metadata needed to drive completion and validity colouring.
+//
+// Returns ok == false when:
+//   - input is empty or ends in a space (no active value token)
+//   - no command word has been entered yet
+//   - the active position is a command word, a flag name without value, or a
+//     value for a non-file argument type
+//   - the active value is empty (e.g. "--path=" with nothing after)
+//
+// valueStart and valueEnd are byte offsets in input that bound the *unquoted*
+// value text. tokenPrefix is whatever leads the active token before the
+// value (flag prefix and/or opening quote). openingQuote is 0 if no quote.
+func activeFileArgument(input string, commands []*Command) (
+	kind ArgumentType,
+	valueStart, valueEnd int,
+	tokenPrefix string,
+	openingQuote rune,
+	ok bool,
+) {
+	if strings.HasSuffix(input, " ") {
+		return
+	}
+	tokens := tokenize(input)
+	if len(tokens) == 0 {
+		return
+	}
+	parts := splitInput(input)
+	if len(parts) == 0 {
+		return
+	}
+
+	finalCmd, depth, globalFlags := walkToFinalCommand(input, parts, commands)
+	if finalCmd == nil {
+		return
+	}
+
+	argParts := parts[depth:]
+	if len(argParts) == 0 {
+		return
+	}
+	posArgs, flagArgs := splitPositionArgsAndFlags(argParts, finalCmd, globalFlags)
+
+	activeToken := tokens[len(tokens)-1]
+	tokenRaw := input[activeToken.Start:activeToken.End]
+
+	// Case 1: equals-form flag value. Distinguished by the active token
+	// being flag-shaped (starts with '-') AND containing an '='.
+	if strings.HasPrefix(activeToken.Unquoted, "-") && strings.Contains(activeToken.Unquoted, "=") {
+		before, _, _ := strings.Cut(tokenRaw, "=")
+		allFlags := slices.Concat(finalCmd.Flags, globalFlags)
+		for _, f := range allFlags {
+			if f.LongFlag != before && f.PsFlag != before {
+				continue
+			}
+			if !isFileLikeArg(f.Type) {
+				return
+			}
+			kind = f.Type
+			eqIdx := strings.IndexByte(tokenRaw, '=')
+			valueStart = activeToken.Start + eqIdx + 1
+			valueEnd = activeToken.End
+			tokenPrefix = tokenRaw[:eqIdx+1]
+			// Inline opening quote after '='?
+			if valueStart < valueEnd {
+				first := input[valueStart]
+				if first == '"' || first == '\'' {
+					openingQuote = rune(first)
+					tokenPrefix += string(openingQuote)
+					valueStart++
+					if valueEnd > valueStart && input[valueEnd-1] == first {
+						valueEnd--
+					}
+				}
+			}
+			ok = valueStart < valueEnd
+			if !ok {
+				return ArgumentType(""), 0, 0, "", 0, false
+			}
+			return kind, valueStart, valueEnd, tokenPrefix, openingQuote, true
+		}
+		// Flag prefix didn't match any known flag — not active.
+		return
+	}
+
+	// Case 2: space-separated flag value. isEnteringFlagValue inspects the
+	// PRECEDING token to see whether it was a flag waiting for a value.
+	if yes, flag := isEnteringFlagValue(input, finalCmd, flagArgs, globalFlags); yes {
+		if !isFileLikeArg(flag.Type) {
+			return
+		}
+		return finalizeTokenRange(activeToken, flag.Type)
+	}
+
+	// Case 3: positional argument value. Two guards:
+	//   - active token must not be a flag-shaped token (the user might be
+	//     typing "--path" — isEnteringPosArgValue would otherwise report
+	//     that as "still typing positional ." for the previous positional)
+	//   - posArgs index must be in bounds for finalCmd.PositionalArguments
+	//     (extra positionals beyond declared = "unexpected argument", not
+	//     an active value position)
+	if !strings.HasPrefix(activeToken.Unquoted, "-") &&
+		len(posArgs) > 0 && len(posArgs) <= len(finalCmd.PositionalArguments) {
+		if yes, pos := isEnteringPosArgValue(input, finalCmd, posArgs); yes {
+			if !isFileLikeArg(pos.Type) {
+				return
+			}
+			return finalizeTokenRange(activeToken, pos.Type)
+		}
+	}
+
+	return
+}
+
+// finalizeTokenRange computes valueStart/valueEnd/tokenPrefix/openingQuote
+// for a positional or space-separated-flag value (Case 2/3 above). The
+// active token's bounds come from [tokenize]; quote handling reflects
+// whether the token opened with a quote and whether that quote was closed.
+func finalizeTokenRange(tok token, kind ArgumentType) (
+	ArgumentType, int, int, string, rune, bool,
+) {
+	valueStart := tok.Start
+	valueEnd := tok.End
+	var tokenPrefix string
+	var openingQuote rune
+	if tok.Quoted {
+		openingQuote = tok.Quote
+		tokenPrefix = string(openingQuote)
+		valueStart++
+		if tok.Closed {
+			valueEnd--
+		}
+	}
+	if valueStart >= valueEnd {
+		return ArgumentType(""), 0, 0, "", 0, false
+	}
+	return kind, valueStart, valueEnd, tokenPrefix, openingQuote, true
+}
+
+// isFileLikeArg reports whether t is one of the filesystem-backed argument
+// types that this feature targets.
+func isFileLikeArg(t ArgumentType) bool {
+	return t == FileArgument || t == DirArgument || t == FileDirArgument
+}
+
+// caseInsensitiveFS is the runtime-derived heuristic for matching policy.
+// Linux is case-sensitive, macOS and Windows are case-insensitive. Documented
+// as a heuristic — case-sensitive APFS volumes on macOS are misclassified.
+func caseInsensitiveFS() bool {
+	return runtime.GOOS != "linux"
+}
+
+// classify decides the path validity for the currently typed value. Stat
+// semantics mirror [validatePath] (uses [os.Stat], which follows symlinks)
+// so green ⇔ Enter accepts.
+func classify(kind ArgumentType, fullClean, base string, entry *dirCacheEntry) pathValidity {
+	if entry.err != nil {
+		return pathInvalid
+	}
+	if base == "" {
+		// Trailing separator on a real directory.
+		switch kind {
+		case DirArgument, FileDirArgument:
+			return pathValid
+		case FileArgument:
+			return pathPartial
+		default:
+			return pathInvalid
+		}
+	}
+
+	if exactMatch(entry, base) {
+		info, err := os.Stat(fullClean)
+		if err != nil {
+			return pathInvalid
+		}
+		return classifyByKind(kind, info.IsDir())
+	}
+	if prefixMatch(entry, base) {
+		return pathPartial
+	}
+	return pathInvalid
+}
+
+// classifyByKind applies the same IsDir() predicate validatePath uses.
+func classifyByKind(kind ArgumentType, isDir bool) pathValidity {
+	switch kind {
+	case FileArgument:
+		if isDir {
+			return pathInvalid
+		}
+		return pathValid
+	case DirArgument:
+		if isDir {
+			return pathValid
+		}
+		return pathInvalid
+	case FileDirArgument:
+		return pathValid
+	default:
+		return pathInvalid
+	}
+}
+
+func exactMatch(entry *dirCacheEntry, base string) bool {
+	if caseInsensitiveFS() {
+		return slices.Contains(entry.foldNames, strings.ToLower(base))
+	}
+	return slices.Contains(entry.names, base)
+}
+
+func prefixMatch(entry *dirCacheEntry, base string) bool {
+	if caseInsensitiveFS() {
+		lower := strings.ToLower(base)
+		for _, n := range entry.foldNames {
+			if strings.HasPrefix(n, lower) {
+				return true
+			}
+		}
+		return false
+	}
+	for _, n := range entry.names {
+		if strings.HasPrefix(n, base) {
+			return true
+		}
+	}
+	return false
+}
+
+// generateCandidates produces the [pathCompletion] list for the active
+// value. Iteration order is the ReadDir result (sorted lex). Survivors are
+// re-sorted dirs-first, case-fold alphabetic, then truncated to limit.
+//
+// Symlink target kinds are resolved via [os.Stat] for entries that survive
+// the prefix and hidden filters; a per-pass cap ([maxSymlinkResolutions])
+// bounds the worst-case stat count.
+func generateCandidates(
+	kind ArgumentType,
+	tokenPrefix, userPrefix string,
+	openingQuote rune,
+	base string,
+	entry *dirCacheEntry,
+	limit int,
+	hiddenFiles bool,
+	parent string,
+) []pathCompletion {
+	if entry.err != nil {
+		return nil
+	}
+	if limit < 1 {
+		limit = 1
+	}
+
+	type prelim struct {
+		name  string
+		isDir bool
+	}
+
+	caseInsensitive := caseInsensitiveFS()
+	lowerBase := strings.ToLower(base)
+	statsRemaining := statBudget(limit)
+	survivors := make([]prelim, 0, min(limit, len(entry.names)))
+
+	for i, name := range entry.names {
+		if !matchesPrefix(name, entry.foldNames[i], base, lowerBase, caseInsensitive) {
+			continue
+		}
+		if !hiddenFiles && strings.HasPrefix(name, ".") && !strings.HasPrefix(base, ".") {
+			continue
+		}
+
+		k := entry.kinds[i]
+		if k == kindSymlink || k == kindUnknown {
+			if statsRemaining <= 0 {
+				continue // budget exhausted; drop
+			}
+			statsRemaining--
+			info, err := os.Stat(filepath.Join(parent, name))
+			if err != nil {
+				continue // broken symlink or stat failure
+			}
+			switch {
+			case info.IsDir():
+				k = kindDir
+			case info.Mode().IsRegular():
+				k = kindFile
+			default:
+				k = kindOther
+			}
+		}
+
+		if !includeKind(kind, k) {
+			continue
+		}
+		survivors = append(survivors, prelim{name: name, isDir: k == kindDir})
+	}
+
+	// Dirs first, then case-fold alphabetic within each group.
+	sort.SliceStable(survivors, func(i, j int) bool {
+		if survivors[i].isDir != survivors[j].isDir {
+			return survivors[i].isDir
+		}
+		return strings.ToLower(survivors[i].name) < strings.ToLower(survivors[j].name)
+	})
+
+	if len(survivors) > limit {
+		survivors = survivors[:limit]
+	}
+
+	out := make([]pathCompletion, len(survivors))
+	for i, s := range survivors {
+		out[i] = buildCompletion(s.name, s.isDir, tokenPrefix, userPrefix, openingQuote)
+	}
+	return out
+}
+
+// matchesPrefix applies the platform's case-sensitivity heuristic.
+func matchesPrefix(name, foldName, base, lowerBase string, caseInsensitive bool) bool {
+	if caseInsensitive {
+		return strings.HasPrefix(foldName, lowerBase)
+	}
+	return strings.HasPrefix(name, base)
+}
+
+// includeKind applies the candidate-inclusion table:
+//   - FileArgument: files + dirs (dirs for drill-down)
+//   - DirArgument:  dirs only
+//   - FileDirArgument: files + dirs
+//
+// Specials (devices, sockets, pipes — kindOther) never appear in candidates,
+// regardless of ArgumentType. Submitting a typed path to a special still
+// classifies and validates per kind, so the invariant holds for any
+// concrete typed path.
+func includeKind(arg ArgumentType, k entryKind) bool {
+	switch k {
+	case kindFile:
+		return arg != DirArgument
+	case kindDir:
+		return true
+	default:
+		return false
+	}
+}
+
+// buildCompletion assembles the displayName and the full active-token
+// replacement string. Quoting:
+//   - openingQuote != 0: keep the user's quote style; restore the closer.
+//   - openingQuote == 0 and the name contains a space: auto-quote with '"'
+//     uniformly for files and directories. The opener slots between any
+//     tokenPrefix (e.g. "--path=") and the userPrefix.
+//
+// Known limitation: filenames containing literal quote characters (" or ')
+// are inserted verbatim, which the tokenizer cannot re-parse as a single
+// token. Such filenames are vanishingly rare in practice and documented as
+// out of scope for v1.
+func buildCompletion(name string, isDir bool, tokenPrefix, userPrefix string, openingQuote rune) pathCompletion {
+	displayName := name
+	if isDir {
+		displayName += "/"
+	}
+
+	insertion := tokenPrefix
+	opener := openingQuote
+	if opener == 0 && strings.ContainsRune(name, ' ') {
+		opener = '"'
+	}
+	if opener != 0 && !strings.HasSuffix(tokenPrefix, string(opener)) {
+		insertion += string(opener)
+	}
+	insertion += userPrefix + name
+	if isDir {
+		insertion += "/"
+	}
+	if opener != 0 {
+		insertion += string(opener)
+	}
+
+	description := "file"
+	if isDir {
+		description = "dir"
+	}
+	return pathCompletion{
+		displayName: displayName,
+		insertion:   insertion,
+		description: description,
+		isDir:       isDir,
+	}
+}

--- a/pathcomplete.go
+++ b/pathcomplete.go
@@ -336,8 +336,8 @@ func prefixMatch(entry *dirCacheEntry, base string) bool {
 // re-sorted dirs-first, case-fold alphabetic, then truncated to limit.
 //
 // Symlink target kinds are resolved via [os.Stat] for entries that survive
-// the prefix and hidden filters; a per-pass cap ([maxSymlinkResolutions])
-// bounds the worst-case stat count.
+// the prefix and hidden filters; [statBudget] bounds the worst-case stat
+// count per pass.
 func generateCandidates(
 	kind ArgumentType,
 	tokenPrefix, userPrefix string,
@@ -356,8 +356,9 @@ func generateCandidates(
 	}
 
 	type prelim struct {
-		name  string
-		isDir bool
+		name      string
+		isDir     bool
+		isSymlink bool // original DirEntry kind was kindSymlink (description hint)
 	}
 
 	caseInsensitive := caseInsensitiveFS()
@@ -374,6 +375,7 @@ func generateCandidates(
 		}
 
 		k := entry.kinds[i]
+		wasSymlink := k == kindSymlink
 		if k == kindSymlink || k == kindUnknown {
 			if statsRemaining <= 0 {
 				continue // budget exhausted; drop
@@ -396,7 +398,7 @@ func generateCandidates(
 		if !includeKind(kind, k) {
 			continue
 		}
-		survivors = append(survivors, prelim{name: name, isDir: k == kindDir})
+		survivors = append(survivors, prelim{name: name, isDir: k == kindDir, isSymlink: wasSymlink})
 	}
 
 	// Dirs first, then case-fold alphabetic within each group.
@@ -413,7 +415,7 @@ func generateCandidates(
 
 	out := make([]pathCompletion, len(survivors))
 	for i, s := range survivors {
-		out[i] = buildCompletion(s.name, s.isDir, tokenPrefix, userPrefix, openingQuote)
+		out[i] = buildCompletion(s.name, s.isDir, s.isSymlink, tokenPrefix, userPrefix, openingQuote)
 	}
 	return out
 }
@@ -453,11 +455,20 @@ func includeKind(arg ArgumentType, k entryKind) bool {
 //     uniformly for files and directories. The opener slots between any
 //     tokenPrefix (e.g. "--path=") and the userPrefix.
 //
+// File completions append a trailing space to the insertion — bash-style
+// "this token is done, move on." Directories deliberately omit the space
+// so the next Tab can drill into the dir's children. Autotrim (default
+// on) strips the trailing space at submit time.
+//
+// When isSymlink is true (the original DirEntry was a symlink, regardless
+// of its target kind), the description carries "symlink → file/dir" so
+// the user can see that the entry isn't a regular file/directory.
+//
 // Known limitation: filenames containing literal quote characters (" or ')
 // are inserted verbatim, which the tokenizer cannot re-parse as a single
 // token. Such filenames are vanishingly rare in practice and documented as
 // out of scope for v1.
-func buildCompletion(name string, isDir bool, tokenPrefix, userPrefix string, openingQuote rune) pathCompletion {
+func buildCompletion(name string, isDir, isSymlink bool, tokenPrefix, userPrefix string, openingQuote rune) pathCompletion {
 	displayName := name
 	if isDir {
 		displayName += "/"
@@ -478,10 +489,17 @@ func buildCompletion(name string, isDir bool, tokenPrefix, userPrefix string, op
 	if opener != 0 {
 		insertion += string(opener)
 	}
+	if !isDir {
+		insertion += " "
+	}
 
-	description := "file"
+	kindLabel := "file"
 	if isDir {
-		description = "dir"
+		kindLabel = "dir"
+	}
+	description := kindLabel
+	if isSymlink {
+		description = "symlink → " + kindLabel
 	}
 	return pathCompletion{
 		displayName: displayName,

--- a/pathcomplete_test.go
+++ b/pathcomplete_test.go
@@ -494,12 +494,13 @@ func TestGenerateCandidates_CaseSensitivity(t *testing.T) {
 
 	cands := generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "BET", entry: entry, limit: 50, hiddenFiles: false, parent: dir})
 	if runtime.GOOS == "linux" {
-		// Case-sensitive: only "Beta/" matches "BET", not "beta.txt".
+		// Case-sensitive: uppercase "BET" matches neither "beta.txt" nor
+		// "Beta/" because the third byte differs (t vs T).
 		if containsName(cands, "beta.txt") {
 			t.Errorf("Linux case-sensitive: beta.txt should NOT match 'BET'")
 		}
-		if !containsName(cands, "Beta/") {
-			t.Errorf("Linux case-sensitive: Beta/ should match 'BET'")
+		if containsName(cands, "Beta/") {
+			t.Errorf("Linux case-sensitive: Beta/ should NOT match 'BET'")
 		}
 	} else if !containsName(cands, "beta.txt") || !containsName(cands, "Beta/") {
 		// Case-insensitive (macOS/Windows heuristic): both surface.

--- a/pathcomplete_test.go
+++ b/pathcomplete_test.go
@@ -1,0 +1,580 @@
+package bubblecomplete
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// fileArgCmd is a minimal command used to exercise activeFileArgument for
+// positional FileArgument values.
+var fileArgCmd = &Command{
+	Command: "cat",
+	PositionalArguments: []*PositionalArgument{
+		{Name: "File", Type: FileArgument, Required: true},
+	},
+}
+
+// dirArgCmd has a positional DirArgument.
+var dirArgCmd = &Command{
+	Command: "cd",
+	PositionalArguments: []*PositionalArgument{
+		{Name: "Dir", Type: DirArgument, Required: true},
+	},
+}
+
+// fileDirArgCmd has a positional FileDirArgument.
+var fileDirArgCmd = &Command{
+	Command: "open",
+	PositionalArguments: []*PositionalArgument{
+		{Name: "Target", Type: FileDirArgument, Required: true},
+	},
+}
+
+// findCmd exercises flag-value paths. --path is a FileArgument flag.
+var findCmd = &Command{
+	Command: "find",
+	PositionalArguments: []*PositionalArgument{
+		{Name: "Dir", Type: DirArgument, Required: true},
+	},
+	Flags: []*Flag{
+		{LongFlag: "--path", Type: FileArgument},
+		{LongFlag: "--name", Type: StringArgument},
+	},
+}
+
+// stringArgCmd has a string positional — should NEVER trigger active path
+// completion regardless of input.
+var stringArgCmd = &Command{
+	Command: "echo",
+	PositionalArguments: []*PositionalArgument{
+		{Name: "Msg", Type: StringArgument, Required: true},
+	},
+}
+
+func cmds(c ...*Command) []*Command { return c }
+
+func TestActiveFileArgument_Inactive(t *testing.T) {
+	cases := []struct {
+		name  string
+		input string
+		cmds  []*Command
+	}{
+		{"empty", "", cmds(fileArgCmd)},
+		{"trailing space", "cat ", cmds(fileArgCmd)},
+		{"no command yet", "ca", cmds(fileArgCmd)},
+		{"unknown command", "wat /tmp/x", cmds(fileArgCmd)},
+		{"string arg type", "echo hello", cmds(stringArgCmd)},
+		{"flag name without value", "find . --path", cmds(findCmd)},
+		{"equals-form empty value", "find . --path=", cmds(findCmd)},
+		{"equals-form unknown flag", "find . --bogus=foo", cmds(findCmd)},
+		{"equals-form non-file flag", "find . --name=foo", cmds(findCmd)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			_, _, _, _, _, ok := activeFileArgument(c.input, c.cmds)
+			if ok {
+				t.Errorf("activeFileArgument(%q) ok=true, want false", c.input)
+			}
+		})
+	}
+}
+
+func TestActiveFileArgument_Positional(t *testing.T) {
+	const input = "cat ~/Doc"
+	kind, vs, ve, tp, oq, ok := activeFileArgument(input, cmds(fileArgCmd))
+	if !ok {
+		t.Fatal("expected active=true")
+	}
+	if kind != FileArgument {
+		t.Errorf("kind = %v, want FileArgument", kind)
+	}
+	if got := input[vs:ve]; got != "~/Doc" {
+		t.Errorf("value = %q, want %q", got, "~/Doc")
+	}
+	if tp != "" {
+		t.Errorf("tokenPrefix = %q, want \"\"", tp)
+	}
+	if oq != 0 {
+		t.Errorf("openingQuote = %q, want 0", oq)
+	}
+}
+
+func TestActiveFileArgument_PositionalQuoted(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		wantVal    string
+		wantPrefix string
+		wantOpener rune
+	}{
+		{"unclosed double", `cat "~/Doc`, "~/Doc", `"`, '"'},
+		{"closed double", `cat "~/Doc"`, "~/Doc", `"`, '"'},
+		{"unclosed single", `cat '~/Doc`, "~/Doc", `'`, '\''},
+		{"closed single", `cat '~/Doc'`, "~/Doc", `'`, '\''},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			kind, vs, ve, tp, oq, ok := activeFileArgument(c.input, cmds(fileArgCmd))
+			if !ok {
+				t.Fatal("expected active=true")
+			}
+			if kind != FileArgument {
+				t.Errorf("kind = %v, want FileArgument", kind)
+			}
+			if got := c.input[vs:ve]; got != c.wantVal {
+				t.Errorf("value = %q, want %q", got, c.wantVal)
+			}
+			if tp != c.wantPrefix {
+				t.Errorf("tokenPrefix = %q, want %q", tp, c.wantPrefix)
+			}
+			if oq != c.wantOpener {
+				t.Errorf("openingQuote = %q, want %q", oq, c.wantOpener)
+			}
+		})
+	}
+}
+
+func TestActiveFileArgument_FlagSpaceSeparated(t *testing.T) {
+	const input = "find . --path ~/Doc"
+	kind, vs, ve, tp, oq, ok := activeFileArgument(input, cmds(findCmd))
+	if !ok {
+		t.Fatal("expected active=true")
+	}
+	if kind != FileArgument {
+		t.Errorf("kind = %v, want FileArgument", kind)
+	}
+	if got := input[vs:ve]; got != "~/Doc" {
+		t.Errorf("value = %q", got)
+	}
+	if tp != "" || oq != 0 {
+		t.Errorf("tokenPrefix=%q opener=%q, want empty/0", tp, oq)
+	}
+}
+
+func TestActiveFileArgument_FlagEqualsForm(t *testing.T) {
+	cases := []struct {
+		name       string
+		input      string
+		wantVal    string
+		wantPrefix string
+		wantOpener rune
+	}{
+		{"unquoted", "find . --path=~/Doc", "~/Doc", "--path=", 0},
+		{"quoted closed", `find . --path="~/Doc"`, "~/Doc", `--path="`, '"'},
+		{"quoted unclosed", `find . --path="~/Doc`, "~/Doc", `--path="`, '"'},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			kind, vs, ve, tp, oq, ok := activeFileArgument(c.input, cmds(findCmd))
+			if !ok {
+				t.Fatal("expected active=true")
+			}
+			if kind != FileArgument {
+				t.Errorf("kind = %v, want FileArgument", kind)
+			}
+			if got := c.input[vs:ve]; got != c.wantVal {
+				t.Errorf("value = %q, want %q", got, c.wantVal)
+			}
+			if tp != c.wantPrefix {
+				t.Errorf("tokenPrefix = %q, want %q", tp, c.wantPrefix)
+			}
+			if oq != c.wantOpener {
+				t.Errorf("openingQuote = %q, want %q", oq, c.wantOpener)
+			}
+		})
+	}
+}
+
+func TestActiveFileArgument_DirAndFileDir(t *testing.T) {
+	if kind, _, _, _, _, ok := activeFileArgument("cd /etc", cmds(dirArgCmd)); !ok || kind != DirArgument {
+		t.Errorf("DirArgument: ok=%v kind=%v", ok, kind)
+	}
+	if kind, _, _, _, _, ok := activeFileArgument("open /etc", cmds(fileDirArgCmd)); !ok || kind != FileDirArgument {
+		t.Errorf("FileDirArgument: ok=%v kind=%v", ok, kind)
+	}
+}
+
+// makeTestDir builds a deterministic test layout under t.TempDir().
+//
+//	tmp/
+//	  alpha.txt
+//	  beta.txt
+//	  Beta/         (case-collision on case-insensitive FS)
+//	  .hidden
+//	  subdir/
+//	    nested.go
+//	  link_alpha  → alpha.txt
+//	  link_dir    → subdir/
+//	  link_broken → nonexistent
+func makeTestDir(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "alpha.txt"))
+	mustWriteFile(t, filepath.Join(dir, "beta.txt"))
+	mustMkdir(t, filepath.Join(dir, "Beta"))
+	mustWriteFile(t, filepath.Join(dir, ".hidden"))
+	mustMkdir(t, filepath.Join(dir, "subdir"))
+	mustWriteFile(t, filepath.Join(dir, "subdir", "nested.go"))
+	if err := os.Symlink(filepath.Join(dir, "alpha.txt"), filepath.Join(dir, "link_alpha")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "subdir"), filepath.Join(dir, "link_dir")); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Symlink(filepath.Join(dir, "nonexistent"), filepath.Join(dir, "link_broken")); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+func TestClassify(t *testing.T) {
+	dir := makeTestDir(t)
+	c := newDirCache()
+	entry := c.read(dir)
+
+	cases := []struct {
+		name string
+		kind ArgumentType
+		base string
+		want pathValidity
+	}{
+		{"file under FileArg → valid", FileArgument, "alpha.txt", pathValid},
+		{"dir under FileArg → invalid (wrong kind)", FileArgument, "subdir", pathInvalid},
+		{"dir under DirArg → valid", DirArgument, "subdir", pathValid},
+		{"file under DirArg → invalid", DirArgument, "alpha.txt", pathInvalid},
+		{"file under FileDirArg → valid", FileDirArgument, "alpha.txt", pathValid},
+		{"dir under FileDirArg → valid", FileDirArgument, "subdir", pathValid},
+		{"prefix under FileArg → partial", FileArgument, "alph", pathPartial},
+		{"no match under FileArg → invalid", FileArgument, "zzz", pathInvalid},
+		{"symlink to file under FileArg → valid", FileArgument, "link_alpha", pathValid},
+		{"symlink to dir under DirArg → valid", DirArgument, "link_dir", pathValid},
+		{"broken symlink under FileArg → invalid", FileArgument, "link_broken", pathInvalid},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fullClean := filepath.Join(dir, tc.base)
+			got := classify(tc.kind, fullClean, tc.base, entry)
+			if got != tc.want {
+				t.Errorf("classify = %d, want %d", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestClassify_TrailingSeparator(t *testing.T) {
+	dir := makeTestDir(t)
+	c := newDirCache()
+	entry := c.read(dir)
+	// base="" simulates the trailing-separator case (e.g. "~/Documents/").
+	if got := classify(DirArgument, dir, "", entry); got != pathValid {
+		t.Errorf("DirArg trailing-sep: got %d, want pathValid", got)
+	}
+	if got := classify(FileDirArgument, dir, "", entry); got != pathValid {
+		t.Errorf("FileDirArg trailing-sep: got %d, want pathValid", got)
+	}
+	if got := classify(FileArgument, dir, "", entry); got != pathPartial {
+		t.Errorf("FileArg trailing-sep: got %d, want pathPartial (mid-nav)", got)
+	}
+}
+
+func TestClassify_PermissionDeniedParent(t *testing.T) {
+	// Use a nonexistent dir to simulate the ReadDir error path. We don't
+	// rely on chmod since that's flaky cross-platform.
+	missing := filepath.Join(t.TempDir(), "does-not-exist")
+	c := newDirCache()
+	entry := c.read(missing)
+	if entry.err == nil {
+		t.Fatal("expected error reading nonexistent dir")
+	}
+	if got := classify(FileArgument, filepath.Join(missing, "foo"), "foo", entry); got != pathInvalid {
+		t.Errorf("classify on err entry = %d, want pathInvalid", got)
+	}
+}
+
+func TestGenerateCandidates_InclusionRules(t *testing.T) {
+	dir := makeTestDir(t)
+	c := newDirCache()
+	entry := c.read(dir)
+
+	// FileArgument: files + dirs (drill-down), no specials.
+	fileCands := generateCandidates(FileArgument, "", "", 0, "", entry, 50, false, dir)
+	if !containsName(fileCands, "alpha.txt") || !containsName(fileCands, "subdir/") {
+		t.Errorf("FileArgument candidates missing files or dirs: %v", names(fileCands))
+	}
+
+	// DirArgument: dirs only.
+	dirCands := generateCandidates(DirArgument, "", "", 0, "", entry, 50, false, dir)
+	for _, c := range dirCands {
+		if !c.isDir {
+			t.Errorf("DirArgument surfaced non-dir %q", c.displayName)
+		}
+	}
+	if !containsName(dirCands, "subdir/") {
+		t.Errorf("DirArgument missing subdir/: %v", names(dirCands))
+	}
+
+	// FileDirArgument: files + dirs.
+	fdCands := generateCandidates(FileDirArgument, "", "", 0, "", entry, 50, false, dir)
+	if !containsName(fdCands, "alpha.txt") || !containsName(fdCands, "subdir/") {
+		t.Errorf("FileDirArgument candidates missing files or dirs: %v", names(fdCands))
+	}
+}
+
+func TestGenerateCandidates_HiddenFiles(t *testing.T) {
+	dir := makeTestDir(t)
+	c := newDirCache()
+	entry := c.read(dir)
+
+	// Default: dotfiles hidden when base prefix doesn't start with '.'.
+	cands := generateCandidates(FileArgument, "", "", 0, "", entry, 50, false, dir)
+	if containsName(cands, ".hidden") {
+		t.Errorf("dotfile leaked into candidates: %v", names(cands))
+	}
+
+	// Typed prefix "." surfaces dotfiles even without the option.
+	cands = generateCandidates(FileArgument, "", "", 0, ".", entry, 50, false, dir)
+	if !containsName(cands, ".hidden") {
+		t.Errorf("dotfile not surfaced for '.' prefix: %v", names(cands))
+	}
+
+	// Option enabled: always surfaced.
+	cands = generateCandidates(FileArgument, "", "", 0, "", entry, 50, true, dir)
+	if !containsName(cands, ".hidden") {
+		t.Errorf("dotfile not surfaced with HiddenFiles=true: %v", names(cands))
+	}
+}
+
+func TestGenerateCandidates_PrefixFilter(t *testing.T) {
+	dir := makeTestDir(t)
+	c := newDirCache()
+	entry := c.read(dir)
+
+	cands := generateCandidates(FileArgument, "", "", 0, "alph", entry, 50, false, dir)
+	if !containsName(cands, "alpha.txt") {
+		t.Errorf("prefix 'alph' should match alpha.txt: %v", names(cands))
+	}
+	for _, c := range cands {
+		stripped := strings.TrimSuffix(c.displayName, "/")
+		lowerStripped := strings.ToLower(stripped)
+		if !strings.HasPrefix(lowerStripped, "alph") {
+			t.Errorf("candidate %q does not match prefix", c.displayName)
+		}
+	}
+}
+
+func TestGenerateCandidates_SymlinkResolution(t *testing.T) {
+	dir := makeTestDir(t)
+	c := newDirCache()
+	entry := c.read(dir)
+
+	// FileArgument: link_alpha (symlink to file) included, link_dir
+	// (symlink to dir) also included (drill-down), link_broken excluded.
+	cands := generateCandidates(FileArgument, "", "", 0, "link", entry, 50, false, dir)
+	if !containsName(cands, "link_alpha") {
+		t.Errorf("link_alpha should be included: %v", names(cands))
+	}
+	if !containsName(cands, "link_dir/") {
+		t.Errorf("link_dir/ should be included: %v", names(cands))
+	}
+	if containsName(cands, "link_broken") || containsName(cands, "link_broken/") {
+		t.Errorf("broken symlink should be excluded: %v", names(cands))
+	}
+
+	// DirArgument: only link_dir.
+	dirCands := generateCandidates(DirArgument, "", "", 0, "link", entry, 50, false, dir)
+	if containsName(dirCands, "link_alpha") {
+		t.Errorf("link_alpha (→file) should NOT be in DirArgument: %v", names(dirCands))
+	}
+	if !containsName(dirCands, "link_dir/") {
+		t.Errorf("link_dir/ should be in DirArgument: %v", names(dirCands))
+	}
+}
+
+func TestGenerateCandidates_SortDirsFirst(t *testing.T) {
+	dir := makeTestDir(t)
+	c := newDirCache()
+	entry := c.read(dir)
+	cands := generateCandidates(FileArgument, "", "", 0, "", entry, 50, false, dir)
+
+	// All directory entries should precede all file entries in the output.
+	sawFile := false
+	for _, c := range cands {
+		if !c.isDir {
+			sawFile = true
+			continue
+		}
+		if sawFile {
+			t.Errorf("dir %q appears after a file in: %v", c.displayName, names(cands))
+		}
+	}
+}
+
+// TestGenerateCandidates_StatBudget pins the budget contract: with more
+// symlinks than statBudget(limit), the surplus symlinks are silently
+// dropped rather than triggering an unbounded stat storm. The output count
+// is at most limit. The test doesn't assert on stat count directly (no
+// instrumentation hook exposed) — it asserts on the contract that the
+// function returns bounded results under a symlink-heavy load and does so
+// without timing out.
+func TestGenerateCandidates_StatBudget(t *testing.T) {
+	dir := t.TempDir()
+	// Real file the symlinks point to.
+	target := filepath.Join(dir, "target.txt")
+	mustWriteFile(t, target)
+
+	// Create symlinks well above the floor (16) so the budget bound is
+	// genuinely exercised. statBudget(limit=2) returns the floor=16.
+	const symlinkCount = 50
+	for i := range symlinkCount {
+		name := filepath.Join(dir, "ln"+padNum(i))
+		if err := os.Symlink(target, name); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	c := newDirCache()
+	entry := c.read(dir)
+
+	cands := generateCandidates(FileArgument, "", "", 0, "ln", entry, 2, false, dir)
+	if len(cands) > 2 {
+		t.Errorf("candidates exceeded limit: got %d, want ≤ 2", len(cands))
+	}
+}
+
+func padNum(i int) string {
+	if i < 10 {
+		return "0" + string(rune('0'+i))
+	}
+	tens := i / 10
+	ones := i % 10
+	return string(rune('0'+tens)) + string(rune('0'+ones))
+}
+
+func TestGenerateCandidates_UnknownTypeResolvedByStat(t *testing.T) {
+	// A "real" DT_UNKNOWN scenario can't easily be forced from userspace,
+	// but we can verify the kindUnknown handling by crafting a dirCacheEntry
+	// manually. This locks in that kindUnknown entries go through stat
+	// (same path as kindSymlink) rather than being misclassified.
+	dir := t.TempDir()
+	mustWriteFile(t, filepath.Join(dir, "real.txt"))
+
+	entry := &dirCacheEntry{
+		names:     []string{"real.txt"},
+		foldNames: []string{"real.txt"},
+		kinds:     []entryKind{kindUnknown}, // forced unknown
+	}
+	cands := generateCandidates(FileArgument, "", "", 0, "real", entry, 10, false, dir)
+	if len(cands) != 1 || cands[0].displayName != "real.txt" {
+		t.Errorf("kindUnknown entry should resolve to file via stat: got %v", names(cands))
+	}
+}
+
+func TestGenerateCandidates_Truncation(t *testing.T) {
+	dir := makeTestDir(t)
+	c := newDirCache()
+	entry := c.read(dir)
+
+	cands := generateCandidates(FileArgument, "", "", 0, "", entry, 2, false, dir)
+	if len(cands) != 2 {
+		t.Errorf("limit=2 → len=%d, want 2", len(cands))
+	}
+}
+
+func TestGenerateCandidates_CaseSensitivity(t *testing.T) {
+	dir := makeTestDir(t)
+	c := newDirCache()
+	entry := c.read(dir)
+
+	cands := generateCandidates(FileArgument, "", "", 0, "BET", entry, 50, false, dir)
+	if runtime.GOOS == "linux" {
+		// Case-sensitive: only "Beta/" matches "BET", not "beta.txt".
+		if containsName(cands, "beta.txt") {
+			t.Errorf("Linux case-sensitive: beta.txt should NOT match 'BET'")
+		}
+		if !containsName(cands, "Beta/") {
+			t.Errorf("Linux case-sensitive: Beta/ should match 'BET'")
+		}
+	} else if !containsName(cands, "beta.txt") || !containsName(cands, "Beta/") {
+		// Case-insensitive (macOS/Windows heuristic): both surface.
+		t.Errorf("case-insensitive: expected both Beta/ and beta.txt for 'BET': %v", names(cands))
+	}
+}
+
+// TestGenerateCandidates_InsertionStrings exercises the full pipeline with
+// non-empty tokenPrefix and openingQuote so the candidate's insertion field
+// reflects the equals-form / quoted-form variants end-to-end. (Without this,
+// the unparam linter flags tokenPrefix/openingQuote as always-zero.)
+func TestGenerateCandidates_InsertionStrings(t *testing.T) {
+	dir := makeTestDir(t)
+	c := newDirCache()
+	entry := c.read(dir)
+
+	// Equals-form unquoted: tokenPrefix="--path=", openingQuote=0.
+	cands := generateCandidates(FileArgument, "--path=", "", 0, "alpha", entry, 10, false, dir)
+	if len(cands) == 0 || cands[0].insertion != "--path=alpha.txt" {
+		t.Errorf("equals-form insertion = %v, want --path=alpha.txt", cands)
+	}
+
+	// Equals-form quoted: tokenPrefix=`--path="`, openingQuote='"'.
+	cands = generateCandidates(FileArgument, `--path="`, "", '"', "alpha", entry, 10, false, dir)
+	if len(cands) == 0 || cands[0].insertion != `--path="alpha.txt"` {
+		t.Errorf("equals-quoted insertion = %v, want --path=\"alpha.txt\"", cands)
+	}
+
+	// Positional quoted with userPrefix preserved.
+	cands = generateCandidates(FileArgument, `"`, "~/", '"', "alpha", entry, 10, false, dir)
+	if len(cands) == 0 || cands[0].insertion != `"~/alpha.txt"` {
+		t.Errorf("quoted positional insertion = %v, want \"~/alpha.txt\"", cands)
+	}
+}
+
+func TestBuildCompletion_Insertion(t *testing.T) {
+	cases := []struct {
+		name        string
+		basename    string
+		isDir       bool
+		tokenPrefix string
+		userPrefix  string
+		opener      rune
+		want        string
+	}{
+		{"plain file", "report.md", false, "", "~/", 0, "~/report.md"},
+		{"plain dir", "Documents", true, "", "~/", 0, "~/Documents/"},
+		{"quoted file", "report.md", false, `"`, "~/", '"', `"~/report.md"`},
+		{"quoted dir", "Documents", true, `"`, "~/", '"', `"~/Documents/"`},
+		{"equals-form file", "report.md", false, "--path=", "~/", 0, "--path=~/report.md"},
+		{"equals-form dir", "Documents", true, "--path=", "~/", 0, "--path=~/Documents/"},
+		{"equals-quoted", "Documents", true, `--path="`, "~/", '"', `--path="~/Documents/"`},
+		{"auto-quote file with space", "My Doc.txt", false, "", "~/", 0, `"~/My Doc.txt"`},
+		{"auto-quote dir with space", "My Documents", true, "", "~/", 0, `"~/My Documents/"`},
+		{"auto-quote equals-form", "My Documents", true, "--path=", "~/", 0, `--path="~/My Documents/"`},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := buildCompletion(tc.basename, tc.isDir, tc.tokenPrefix, tc.userPrefix, tc.opener)
+			if got.insertion != tc.want {
+				t.Errorf("insertion = %q, want %q", got.insertion, tc.want)
+			}
+		})
+	}
+}
+
+func containsName(cands []pathCompletion, name string) bool {
+	for _, c := range cands {
+		if c.displayName == name {
+			return true
+		}
+	}
+	return false
+}
+
+func names(cands []pathCompletion) []string {
+	out := make([]string, len(cands))
+	for i, c := range cands {
+		out[i] = c.displayName
+	}
+	return out
+}

--- a/pathcomplete_test.go
+++ b/pathcomplete_test.go
@@ -74,7 +74,7 @@ func TestActiveFileArgument_Inactive(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, _, _, _, _, _, ok := activeFileArgument(c.input, c.cmds)
+			_, ok := activeFileArgument(c.input, c.cmds)
 			if ok {
 				t.Errorf("activeFileArgument(%q) ok=true, want false", c.input)
 			}
@@ -84,7 +84,8 @@ func TestActiveFileArgument_Inactive(t *testing.T) {
 
 func TestActiveFileArgument_Positional(t *testing.T) {
 	const input = "cat ~/Doc"
-	kind, _, vs, ve, tp, oq, ok := activeFileArgument(input, cmds(fileArgCmd))
+	a, ok := activeFileArgument(input, cmds(fileArgCmd))
+	kind, vs, ve, tp, oq := a.kind, a.valueStart, a.valueEnd, a.tokenPrefix, a.openingQuote
 	if !ok {
 		t.Fatal("expected active=true")
 	}
@@ -117,7 +118,8 @@ func TestActiveFileArgument_PositionalQuoted(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			kind, _, vs, ve, tp, oq, ok := activeFileArgument(c.input, cmds(fileArgCmd))
+			a, ok := activeFileArgument(c.input, cmds(fileArgCmd))
+			kind, vs, ve, tp, oq := a.kind, a.valueStart, a.valueEnd, a.tokenPrefix, a.openingQuote
 			if !ok {
 				t.Fatal("expected active=true")
 			}
@@ -139,7 +141,8 @@ func TestActiveFileArgument_PositionalQuoted(t *testing.T) {
 
 func TestActiveFileArgument_FlagSpaceSeparated(t *testing.T) {
 	const input = "find . --path ~/Doc"
-	kind, _, vs, ve, tp, oq, ok := activeFileArgument(input, cmds(findCmd))
+	a, ok := activeFileArgument(input, cmds(findCmd))
+	kind, vs, ve, tp, oq := a.kind, a.valueStart, a.valueEnd, a.tokenPrefix, a.openingQuote
 	if !ok {
 		t.Fatal("expected active=true")
 	}
@@ -168,7 +171,8 @@ func TestActiveFileArgument_FlagEqualsForm(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			kind, _, vs, ve, tp, oq, ok := activeFileArgument(c.input, cmds(findCmd))
+			a, ok := activeFileArgument(c.input, cmds(findCmd))
+			kind, vs, ve, tp, oq := a.kind, a.valueStart, a.valueEnd, a.tokenPrefix, a.openingQuote
 			if !ok {
 				t.Fatal("expected active=true")
 			}
@@ -189,11 +193,11 @@ func TestActiveFileArgument_FlagEqualsForm(t *testing.T) {
 }
 
 func TestActiveFileArgument_DirAndFileDir(t *testing.T) {
-	if kind, _, _, _, _, _, ok := activeFileArgument("cd /etc", cmds(dirArgCmd)); !ok || kind != DirArgument {
-		t.Errorf("DirArgument: ok=%v kind=%v", ok, kind)
+	if a, ok := activeFileArgument("cd /etc", cmds(dirArgCmd)); !ok || a.kind != DirArgument {
+		t.Errorf("DirArgument: ok=%v kind=%v", ok, a.kind)
 	}
-	if kind, _, _, _, _, _, ok := activeFileArgument("open /etc", cmds(fileDirArgCmd)); !ok || kind != FileDirArgument {
-		t.Errorf("FileDirArgument: ok=%v kind=%v", ok, kind)
+	if a, ok := activeFileArgument("open /etc", cmds(fileDirArgCmd)); !ok || a.kind != FileDirArgument {
+		t.Errorf("FileDirArgument: ok=%v kind=%v", ok, a.kind)
 	}
 }
 
@@ -300,13 +304,13 @@ func TestGenerateCandidates_InclusionRules(t *testing.T) {
 	entry := c.read(dir)
 
 	// FileArgument: files + dirs (drill-down), no specials.
-	fileCands := generateCandidates(FileArgument, "", "", 0, "", entry, 50, false, dir)
+	fileCands := generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "", entry: entry, limit: 50, hiddenFiles: false, parent: dir})
 	if !containsName(fileCands, "alpha.txt") || !containsName(fileCands, "subdir/") {
 		t.Errorf("FileArgument candidates missing files or dirs: %v", names(fileCands))
 	}
 
 	// DirArgument: dirs only.
-	dirCands := generateCandidates(DirArgument, "", "", 0, "", entry, 50, false, dir)
+	dirCands := generateCandidates(candidateRequest{kind: DirArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "", entry: entry, limit: 50, hiddenFiles: false, parent: dir})
 	for _, c := range dirCands {
 		if !c.isDir {
 			t.Errorf("DirArgument surfaced non-dir %q", c.displayName)
@@ -317,7 +321,7 @@ func TestGenerateCandidates_InclusionRules(t *testing.T) {
 	}
 
 	// FileDirArgument: files + dirs.
-	fdCands := generateCandidates(FileDirArgument, "", "", 0, "", entry, 50, false, dir)
+	fdCands := generateCandidates(candidateRequest{kind: FileDirArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "", entry: entry, limit: 50, hiddenFiles: false, parent: dir})
 	if !containsName(fdCands, "alpha.txt") || !containsName(fdCands, "subdir/") {
 		t.Errorf("FileDirArgument candidates missing files or dirs: %v", names(fdCands))
 	}
@@ -329,19 +333,19 @@ func TestGenerateCandidates_HiddenFiles(t *testing.T) {
 	entry := c.read(dir)
 
 	// Default: dotfiles hidden when base prefix doesn't start with '.'.
-	cands := generateCandidates(FileArgument, "", "", 0, "", entry, 50, false, dir)
+	cands := generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "", entry: entry, limit: 50, hiddenFiles: false, parent: dir})
 	if containsName(cands, ".hidden") {
 		t.Errorf("dotfile leaked into candidates: %v", names(cands))
 	}
 
 	// Typed prefix "." surfaces dotfiles even without the option.
-	cands = generateCandidates(FileArgument, "", "", 0, ".", entry, 50, false, dir)
+	cands = generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: ".", entry: entry, limit: 50, hiddenFiles: false, parent: dir})
 	if !containsName(cands, ".hidden") {
 		t.Errorf("dotfile not surfaced for '.' prefix: %v", names(cands))
 	}
 
 	// Option enabled: always surfaced.
-	cands = generateCandidates(FileArgument, "", "", 0, "", entry, 50, true, dir)
+	cands = generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "", entry: entry, limit: 50, hiddenFiles: true, parent: dir})
 	if !containsName(cands, ".hidden") {
 		t.Errorf("dotfile not surfaced with HiddenFiles=true: %v", names(cands))
 	}
@@ -352,7 +356,7 @@ func TestGenerateCandidates_PrefixFilter(t *testing.T) {
 	c := newDirCache()
 	entry := c.read(dir)
 
-	cands := generateCandidates(FileArgument, "", "", 0, "alph", entry, 50, false, dir)
+	cands := generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "alph", entry: entry, limit: 50, hiddenFiles: false, parent: dir})
 	if !containsName(cands, "alpha.txt") {
 		t.Errorf("prefix 'alph' should match alpha.txt: %v", names(cands))
 	}
@@ -372,7 +376,7 @@ func TestGenerateCandidates_SymlinkResolution(t *testing.T) {
 
 	// FileArgument: link_alpha (symlink to file) included, link_dir
 	// (symlink to dir) also included (drill-down), link_broken excluded.
-	cands := generateCandidates(FileArgument, "", "", 0, "link", entry, 50, false, dir)
+	cands := generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "link", entry: entry, limit: 50, hiddenFiles: false, parent: dir})
 	if !containsName(cands, "link_alpha") {
 		t.Errorf("link_alpha should be included: %v", names(cands))
 	}
@@ -384,7 +388,7 @@ func TestGenerateCandidates_SymlinkResolution(t *testing.T) {
 	}
 
 	// DirArgument: only link_dir.
-	dirCands := generateCandidates(DirArgument, "", "", 0, "link", entry, 50, false, dir)
+	dirCands := generateCandidates(candidateRequest{kind: DirArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "link", entry: entry, limit: 50, hiddenFiles: false, parent: dir})
 	if containsName(dirCands, "link_alpha") {
 		t.Errorf("link_alpha (→file) should NOT be in DirArgument: %v", names(dirCands))
 	}
@@ -397,7 +401,7 @@ func TestGenerateCandidates_SortDirsFirst(t *testing.T) {
 	dir := makeTestDir(t)
 	c := newDirCache()
 	entry := c.read(dir)
-	cands := generateCandidates(FileArgument, "", "", 0, "", entry, 50, false, dir)
+	cands := generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "", entry: entry, limit: 50, hiddenFiles: false, parent: dir})
 
 	// All directory entries should precede all file entries in the output.
 	sawFile := false
@@ -438,7 +442,7 @@ func TestGenerateCandidates_StatBudget(t *testing.T) {
 	c := newDirCache()
 	entry := c.read(dir)
 
-	cands := generateCandidates(FileArgument, "", "", 0, "ln", entry, 2, false, dir)
+	cands := generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "ln", entry: entry, limit: 2, hiddenFiles: false, parent: dir})
 	if len(cands) > 2 {
 		t.Errorf("candidates exceeded limit: got %d, want ≤ 2", len(cands))
 	}
@@ -466,7 +470,7 @@ func TestGenerateCandidates_UnknownTypeResolvedByStat(t *testing.T) {
 		foldNames: []string{"real.txt"},
 		kinds:     []entryKind{kindUnknown}, // forced unknown
 	}
-	cands := generateCandidates(FileArgument, "", "", 0, "real", entry, 10, false, dir)
+	cands := generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "real", entry: entry, limit: 10, hiddenFiles: false, parent: dir})
 	if len(cands) != 1 || cands[0].displayName != "real.txt" {
 		t.Errorf("kindUnknown entry should resolve to file via stat: got %v", names(cands))
 	}
@@ -477,7 +481,7 @@ func TestGenerateCandidates_Truncation(t *testing.T) {
 	c := newDirCache()
 	entry := c.read(dir)
 
-	cands := generateCandidates(FileArgument, "", "", 0, "", entry, 2, false, dir)
+	cands := generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "", entry: entry, limit: 2, hiddenFiles: false, parent: dir})
 	if len(cands) != 2 {
 		t.Errorf("limit=2 → len=%d, want 2", len(cands))
 	}
@@ -488,7 +492,7 @@ func TestGenerateCandidates_CaseSensitivity(t *testing.T) {
 	c := newDirCache()
 	entry := c.read(dir)
 
-	cands := generateCandidates(FileArgument, "", "", 0, "BET", entry, 50, false, dir)
+	cands := generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "BET", entry: entry, limit: 50, hiddenFiles: false, parent: dir})
 	if runtime.GOOS == "linux" {
 		// Case-sensitive: only "Beta/" matches "BET", not "beta.txt".
 		if containsName(cands, "beta.txt") {
@@ -514,19 +518,19 @@ func TestGenerateCandidates_InsertionStrings(t *testing.T) {
 
 	// Equals-form unquoted: tokenPrefix="--path=", openingQuote=0. File
 	// completions get a trailing space.
-	cands := generateCandidates(FileArgument, "--path=", "", 0, "alpha", entry, 10, false, dir)
+	cands := generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "--path=", base: "alpha", entry: entry, limit: 10, parent: dir})
 	if len(cands) == 0 || cands[0].insertion != "--path=alpha.txt " {
 		t.Errorf("equals-form insertion = %v, want --path=alpha.txt (with trailing space)", cands)
 	}
 
 	// Equals-form quoted: tokenPrefix=`--path="`, openingQuote='"'.
-	cands = generateCandidates(FileArgument, `--path="`, "", '"', "alpha", entry, 10, false, dir)
+	cands = generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: `--path="`, userPrefix: "", openingQuote: '"', base: "alpha", entry: entry, limit: 10, hiddenFiles: false, parent: dir})
 	if len(cands) == 0 || cands[0].insertion != `--path="alpha.txt" ` {
 		t.Errorf("equals-quoted insertion = %v, want --path=\"alpha.txt\" (with trailing space)", cands)
 	}
 
 	// Positional quoted with userPrefix preserved.
-	cands = generateCandidates(FileArgument, `"`, "~/", '"', "alpha", entry, 10, false, dir)
+	cands = generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: `"`, userPrefix: "~/", openingQuote: '"', base: "alpha", entry: entry, limit: 10, hiddenFiles: false, parent: dir})
 	if len(cands) == 0 || cands[0].insertion != `"~/alpha.txt" ` {
 		t.Errorf("quoted positional insertion = %v, want \"~/alpha.txt\" (with trailing space)", cands)
 	}
@@ -576,7 +580,7 @@ func TestGenerateCandidates_SymlinkDescription(t *testing.T) {
 	c := newDirCache()
 	entry := c.read(dir)
 
-	cands := generateCandidates(FileArgument, "", "", 0, "link", entry, 50, false, dir)
+	cands := generateCandidates(candidateRequest{kind: FileArgument, tokenPrefix: "", userPrefix: "", openingQuote: 0, base: "link", entry: entry, limit: 50, hiddenFiles: false, parent: dir})
 
 	var alphaDesc, dirDesc string
 	for _, candidate := range cands {

--- a/pathcomplete_test.go
+++ b/pathcomplete_test.go
@@ -74,7 +74,7 @@ func TestActiveFileArgument_Inactive(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			_, _, _, _, _, ok := activeFileArgument(c.input, c.cmds)
+			_, _, _, _, _, _, ok := activeFileArgument(c.input, c.cmds)
 			if ok {
 				t.Errorf("activeFileArgument(%q) ok=true, want false", c.input)
 			}
@@ -84,7 +84,7 @@ func TestActiveFileArgument_Inactive(t *testing.T) {
 
 func TestActiveFileArgument_Positional(t *testing.T) {
 	const input = "cat ~/Doc"
-	kind, vs, ve, tp, oq, ok := activeFileArgument(input, cmds(fileArgCmd))
+	kind, _, vs, ve, tp, oq, ok := activeFileArgument(input, cmds(fileArgCmd))
 	if !ok {
 		t.Fatal("expected active=true")
 	}
@@ -117,7 +117,7 @@ func TestActiveFileArgument_PositionalQuoted(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			kind, vs, ve, tp, oq, ok := activeFileArgument(c.input, cmds(fileArgCmd))
+			kind, _, vs, ve, tp, oq, ok := activeFileArgument(c.input, cmds(fileArgCmd))
 			if !ok {
 				t.Fatal("expected active=true")
 			}
@@ -139,7 +139,7 @@ func TestActiveFileArgument_PositionalQuoted(t *testing.T) {
 
 func TestActiveFileArgument_FlagSpaceSeparated(t *testing.T) {
 	const input = "find . --path ~/Doc"
-	kind, vs, ve, tp, oq, ok := activeFileArgument(input, cmds(findCmd))
+	kind, _, vs, ve, tp, oq, ok := activeFileArgument(input, cmds(findCmd))
 	if !ok {
 		t.Fatal("expected active=true")
 	}
@@ -168,7 +168,7 @@ func TestActiveFileArgument_FlagEqualsForm(t *testing.T) {
 	}
 	for _, c := range cases {
 		t.Run(c.name, func(t *testing.T) {
-			kind, vs, ve, tp, oq, ok := activeFileArgument(c.input, cmds(findCmd))
+			kind, _, vs, ve, tp, oq, ok := activeFileArgument(c.input, cmds(findCmd))
 			if !ok {
 				t.Fatal("expected active=true")
 			}
@@ -189,10 +189,10 @@ func TestActiveFileArgument_FlagEqualsForm(t *testing.T) {
 }
 
 func TestActiveFileArgument_DirAndFileDir(t *testing.T) {
-	if kind, _, _, _, _, ok := activeFileArgument("cd /etc", cmds(dirArgCmd)); !ok || kind != DirArgument {
+	if kind, _, _, _, _, _, ok := activeFileArgument("cd /etc", cmds(dirArgCmd)); !ok || kind != DirArgument {
 		t.Errorf("DirArgument: ok=%v kind=%v", ok, kind)
 	}
-	if kind, _, _, _, _, ok := activeFileArgument("open /etc", cmds(fileDirArgCmd)); !ok || kind != FileDirArgument {
+	if kind, _, _, _, _, _, ok := activeFileArgument("open /etc", cmds(fileDirArgCmd)); !ok || kind != FileDirArgument {
 		t.Errorf("FileDirArgument: ok=%v kind=%v", ok, kind)
 	}
 }

--- a/pathcomplete_test.go
+++ b/pathcomplete_test.go
@@ -512,26 +512,29 @@ func TestGenerateCandidates_InsertionStrings(t *testing.T) {
 	c := newDirCache()
 	entry := c.read(dir)
 
-	// Equals-form unquoted: tokenPrefix="--path=", openingQuote=0.
+	// Equals-form unquoted: tokenPrefix="--path=", openingQuote=0. File
+	// completions get a trailing space.
 	cands := generateCandidates(FileArgument, "--path=", "", 0, "alpha", entry, 10, false, dir)
-	if len(cands) == 0 || cands[0].insertion != "--path=alpha.txt" {
-		t.Errorf("equals-form insertion = %v, want --path=alpha.txt", cands)
+	if len(cands) == 0 || cands[0].insertion != "--path=alpha.txt " {
+		t.Errorf("equals-form insertion = %v, want --path=alpha.txt (with trailing space)", cands)
 	}
 
 	// Equals-form quoted: tokenPrefix=`--path="`, openingQuote='"'.
 	cands = generateCandidates(FileArgument, `--path="`, "", '"', "alpha", entry, 10, false, dir)
-	if len(cands) == 0 || cands[0].insertion != `--path="alpha.txt"` {
-		t.Errorf("equals-quoted insertion = %v, want --path=\"alpha.txt\"", cands)
+	if len(cands) == 0 || cands[0].insertion != `--path="alpha.txt" ` {
+		t.Errorf("equals-quoted insertion = %v, want --path=\"alpha.txt\" (with trailing space)", cands)
 	}
 
 	// Positional quoted with userPrefix preserved.
 	cands = generateCandidates(FileArgument, `"`, "~/", '"', "alpha", entry, 10, false, dir)
-	if len(cands) == 0 || cands[0].insertion != `"~/alpha.txt"` {
-		t.Errorf("quoted positional insertion = %v, want \"~/alpha.txt\"", cands)
+	if len(cands) == 0 || cands[0].insertion != `"~/alpha.txt" ` {
+		t.Errorf("quoted positional insertion = %v, want \"~/alpha.txt\" (with trailing space)", cands)
 	}
 }
 
 func TestBuildCompletion_Insertion(t *testing.T) {
+	// File completions append a trailing space (bash-style "token done");
+	// directory completions deliberately omit it so the next Tab drills in.
 	cases := []struct {
 		name        string
 		basename    string
@@ -541,24 +544,70 @@ func TestBuildCompletion_Insertion(t *testing.T) {
 		opener      rune
 		want        string
 	}{
-		{"plain file", "report.md", false, "", "~/", 0, "~/report.md"},
+		{"plain file", "report.md", false, "", "~/", 0, "~/report.md "},
 		{"plain dir", "Documents", true, "", "~/", 0, "~/Documents/"},
-		{"quoted file", "report.md", false, `"`, "~/", '"', `"~/report.md"`},
+		{"quoted file", "report.md", false, `"`, "~/", '"', `"~/report.md" `},
 		{"quoted dir", "Documents", true, `"`, "~/", '"', `"~/Documents/"`},
-		{"equals-form file", "report.md", false, "--path=", "~/", 0, "--path=~/report.md"},
+		{"equals-form file", "report.md", false, "--path=", "~/", 0, "--path=~/report.md "},
 		{"equals-form dir", "Documents", true, "--path=", "~/", 0, "--path=~/Documents/"},
 		{"equals-quoted", "Documents", true, `--path="`, "~/", '"', `--path="~/Documents/"`},
-		{"auto-quote file with space", "My Doc.txt", false, "", "~/", 0, `"~/My Doc.txt"`},
+		{"auto-quote file with space", "My Doc.txt", false, "", "~/", 0, `"~/My Doc.txt" `},
 		{"auto-quote dir with space", "My Documents", true, "", "~/", 0, `"~/My Documents/"`},
 		{"auto-quote equals-form", "My Documents", true, "--path=", "~/", 0, `--path="~/My Documents/"`},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := buildCompletion(tc.basename, tc.isDir, tc.tokenPrefix, tc.userPrefix, tc.opener)
+			got := buildCompletion(tc.basename, tc.isDir, false, tc.tokenPrefix, tc.userPrefix, tc.opener)
 			if got.insertion != tc.want {
 				t.Errorf("insertion = %q, want %q", got.insertion, tc.want)
 			}
 		})
+	}
+}
+
+// TestGenerateCandidates_SymlinkDescription locks in the wasSymlink
+// plumbing end-to-end: generateCandidates resolves a symlink via stat and
+// surfaces "symlink → file" / "symlink → dir" in the description, not just
+// the resolved kind. The buildCompletion unit test covers the formatting;
+// this exercises the full pipeline including the original-kind capture
+// before stat resolution rewrites it.
+func TestGenerateCandidates_SymlinkDescription(t *testing.T) {
+	dir := makeTestDir(t)
+	c := newDirCache()
+	entry := c.read(dir)
+
+	cands := generateCandidates(FileArgument, "", "", 0, "link", entry, 50, false, dir)
+
+	var alphaDesc, dirDesc string
+	for _, candidate := range cands {
+		switch candidate.displayName {
+		case "link_alpha":
+			alphaDesc = candidate.description
+		case "link_dir/":
+			dirDesc = candidate.description
+		}
+	}
+	if alphaDesc != "symlink → file" {
+		t.Errorf("link_alpha description = %q, want %q", alphaDesc, "symlink → file")
+	}
+	if dirDesc != "symlink → dir" {
+		t.Errorf("link_dir/ description = %q, want %q", dirDesc, "symlink → dir")
+	}
+}
+
+func TestBuildCompletion_SymlinkDescription(t *testing.T) {
+	got := buildCompletion("link_to_file", false, true, "", "", 0)
+	if got.description != "symlink → file" {
+		t.Errorf("symlink-to-file description = %q, want %q", got.description, "symlink → file")
+	}
+	got = buildCompletion("link_to_dir", true, true, "", "", 0)
+	if got.description != "symlink → dir" {
+		t.Errorf("symlink-to-dir description = %q, want %q", got.description, "symlink → dir")
+	}
+	// Non-symlink keeps the plain description.
+	got = buildCompletion("regular.txt", false, false, "", "", 0)
+	if got.description != "file" {
+		t.Errorf("regular-file description = %q, want %q", got.description, "file")
 	}
 }
 

--- a/pathresolve.go
+++ b/pathresolve.go
@@ -1,0 +1,140 @@
+package bubblecomplete
+
+import (
+	"path/filepath"
+	"strings"
+)
+
+// stripQuotes performs simple outer-quote stripping. If s begins with a
+// recognised quote character (" or '), the opening byte is always removed;
+// the trailing byte is also removed when it equals the opener. Returns the
+// stripped text plus the opening quote rune (0 if no quote).
+//
+// Behaviour:
+//
+//	`~/Doc`     → ("~/Doc", 0)         (no opener)
+//	`"~/Doc`    → ("~/Doc", '"')       (unclosed opener)
+//	`"~/Doc"`   → ("~/Doc", '"')       (matched pair)
+//	`'~/Doc'`   → ("~/Doc", '\'')      (matched pair)
+//	`"foo"bar"` → (`foo"bar`, '"')     (outer-strip; embedded quote is kept)
+//
+// Embedded quotes (`"foo"bar"`) are not produced by the tokenizer — it splits
+// on the first matched closer — so the last case is only reachable when a
+// caller passes a pre-assembled string. Outer-strip semantics are simple and
+// adequate because submit-time callers run [checkUnclosedQuote] first, and
+// editing-time callers use it on tokenizer output where the case can't arise.
+func stripQuotes(s string) (unquoted string, opener rune) {
+	if s == "" {
+		return s, 0
+	}
+	first := s[0]
+	if first != '"' && first != '\'' {
+		return s, 0
+	}
+	opener = rune(first)
+	body := s[1:]
+	if len(body) >= 1 && body[len(body)-1] == first {
+		return body[:len(body)-1], opener
+	}
+	return body, opener
+}
+
+// resolvePath canonicalises an already-unquoted path value. Pure given the
+// inputs.
+//
+// expandTilde controls whether a leading "~" or "~/" is expanded against
+// home. By library convention, callers set expandTilde true when the value
+// is unquoted or inside double quotes, and false when inside single quotes
+// — matching shell behaviour. A bare "~" is normalised to "~/" for both
+// resolution and userPrefix, regardless of expandTilde.
+//
+// fullClean is filepath.Clean'd. It is absolute when the typed path is
+// absolute OR cwd is non-empty. When cwd == "" and the typed path is
+// relative, fullClean stays relative — os.Stat then uses the process CWD,
+// matching today's validatePath behaviour when os.Getwd errors.
+//
+// parent ends with a separator when base is empty (the user typed a
+// trailing separator) so consumers can ReadDir(parent) uniformly. parent
+// and base together reconstruct fullClean.
+//
+// userPrefix is the leading bytes of typed (after the bare-tilde fixup) up
+// to and including the last separator before base — preserved verbatim so
+// insertions keep the user's style (e.g. "~/" rather than the expanded
+// "/Users/jane/").
+//
+// For an empty typed string, resolvePath returns four empty strings.
+func resolvePath(typed, cwd, home string, expandTilde bool) (fullClean, parent, base, userPrefix string) {
+	if typed == "" {
+		return "", "", "", ""
+	}
+
+	// Normalise bare "~" to "~/" for both resolution and userPrefix. The
+	// user typing just "~" expects to navigate into home, not to complete a
+	// sibling of home (which is what the strict reading would imply).
+	if typed == "~" {
+		typed = "~/"
+	}
+
+	// userPrefix is derived from the (possibly normalised) typed string,
+	// before any tilde expansion or CWD joining.
+	if i := lastSeparatorIndex(typed); i >= 0 {
+		userPrefix = typed[:i+1]
+	}
+
+	endsWithSep := endsInSeparator(typed)
+
+	// Tilde expansion.
+	expanded := typed
+	if expandTilde && home != "" && strings.HasPrefix(typed, "~") {
+		switch {
+		case typed == "~/":
+			expanded = home
+		case len(typed) >= 2 && (typed[1] == '/' || typed[1] == filepath.Separator):
+			expanded = filepath.Join(home, typed[2:])
+		}
+	}
+
+	// Join relative with cwd.
+	joined := expanded
+	if !filepath.IsAbs(expanded) && cwd != "" {
+		joined = filepath.Join(cwd, expanded)
+	}
+
+	fullClean = filepath.Clean(joined)
+
+	if endsWithSep {
+		parent = fullClean
+		if !endsInSeparator(parent) {
+			parent += string(filepath.Separator)
+		}
+		base = ""
+	} else {
+		parent, base = filepath.Split(fullClean)
+	}
+
+	return fullClean, parent, base, userPrefix
+}
+
+// endsInSeparator reports whether s ends with '/' or filepath.Separator.
+// On Linux filepath.Separator is '/' so both checks collapse; on Windows
+// '\\' is also accepted because Go's filepath package treats both forms
+// equivalently.
+func endsInSeparator(s string) bool {
+	if s == "" {
+		return false
+	}
+	c := s[len(s)-1]
+	return c == '/' || c == filepath.Separator
+}
+
+// lastSeparatorIndex returns the byte index of the last '/' or
+// filepath.Separator in s, or -1 if none.
+func lastSeparatorIndex(s string) int {
+	i := strings.LastIndexByte(s, '/')
+	if filepath.Separator != '/' {
+		if j := strings.LastIndexByte(s, byte(filepath.Separator)); j > i {
+			i = j
+		}
+	}
+	return i
+}

--- a/pathresolve_test.go
+++ b/pathresolve_test.go
@@ -1,0 +1,332 @@
+package bubblecomplete
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestStripQuotes(t *testing.T) {
+	cases := []struct {
+		name     string
+		in       string
+		wantOut  string
+		wantQuot rune
+	}{
+		{"empty", "", "", 0},
+		{"no quote", "~/Doc", "~/Doc", 0},
+		{"matched double", `"~/Doc"`, "~/Doc", '"'},
+		{"matched single", `'~/Doc'`, "~/Doc", '\''},
+		{"unclosed double", `"~/Doc`, "~/Doc", '"'},
+		{"unclosed single", `'~/Doc`, "~/Doc", '\''},
+		{"only opener double", `"`, "", '"'},
+		{"only opener single", `'`, "", '\''},
+		{"pair just quotes", `""`, "", '"'},
+		{"mismatched closers stay literal", `"foo'`, "foo'", '"'},
+		{"outer strip with embedded quote", `"foo"bar"`, `foo"bar`, '"'},
+		{"leading non-quote is no-op", `x"foo"`, `x"foo"`, 0},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			out, q := stripQuotes(c.in)
+			if out != c.wantOut {
+				t.Errorf("unquoted = %q, want %q", out, c.wantOut)
+			}
+			if q != c.wantQuot {
+				t.Errorf("opener = %q (%d), want %q (%d)", q, q, c.wantQuot, c.wantQuot)
+			}
+		})
+	}
+}
+
+func TestResolvePath(t *testing.T) {
+	// Canonical fixtures. cwd and home are *strings* — the resolver is pure,
+	// so we don't need real directories.
+	const (
+		cwd  = "/work"
+		home = "/Users/jane"
+	)
+
+	cases := []struct {
+		name           string
+		typed          string
+		cwd            string
+		home           string
+		expandTilde    bool
+		wantFullClean  string
+		wantParent     string
+		wantBase       string
+		wantUserPrefix string
+	}{
+		{
+			name:           "empty",
+			typed:          "",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "",
+			wantParent:     "",
+			wantBase:       "",
+			wantUserPrefix: "",
+		},
+		{
+			name:           "relative no separator",
+			typed:          "Doc",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/work/Doc",
+			wantParent:     "/work/",
+			wantBase:       "Doc",
+			wantUserPrefix: "",
+		},
+		{
+			name:           "relative with separator",
+			typed:          "sub/Doc",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/work/sub/Doc",
+			wantParent:     "/work/sub/",
+			wantBase:       "Doc",
+			wantUserPrefix: "sub/",
+		},
+		{
+			name:           "dot-prefix relative",
+			typed:          "./Doc",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/work/Doc",
+			wantParent:     "/work/",
+			wantBase:       "Doc",
+			wantUserPrefix: "./",
+		},
+		{
+			name:           "absolute file",
+			typed:          "/abs/path/file.txt",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/abs/path/file.txt",
+			wantParent:     "/abs/path/",
+			wantBase:       "file.txt",
+			wantUserPrefix: "/abs/path/",
+		},
+		{
+			name:           "absolute trailing slash",
+			typed:          "/abs/path/",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/abs/path",
+			wantParent:     "/abs/path/",
+			wantBase:       "",
+			wantUserPrefix: "/abs/path/",
+		},
+		{
+			name:           "bare tilde with expansion",
+			typed:          "~",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/Users/jane",
+			wantParent:     "/Users/jane/",
+			wantBase:       "",
+			wantUserPrefix: "~/",
+		},
+		{
+			// Bare ~ is normalised to ~/ regardless of expandTilde, so even
+			// the no-expand path produces userPrefix "~/" and a trailing-slash
+			// classification. The resolved fullClean is cwd/~ (literal),
+			// because expandTilde=false leaves ~ alone.
+			name:           "bare tilde without expansion",
+			typed:          "~",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    false,
+			wantFullClean:  "/work/~",
+			wantParent:     "/work/~/",
+			wantBase:       "",
+			wantUserPrefix: "~/",
+		},
+		{
+			name:           "tilde slash with expansion",
+			typed:          "~/",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/Users/jane",
+			wantParent:     "/Users/jane/",
+			wantBase:       "",
+			wantUserPrefix: "~/",
+		},
+		{
+			name:           "tilde prefix with subpath",
+			typed:          "~/Doc",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/Users/jane/Doc",
+			wantParent:     "/Users/jane/",
+			wantBase:       "Doc",
+			wantUserPrefix: "~/",
+		},
+		{
+			name:           "tilde prefix deep",
+			typed:          "~/Documents/report.md",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/Users/jane/Documents/report.md",
+			wantParent:     "/Users/jane/Documents/",
+			wantBase:       "report.md",
+			wantUserPrefix: "~/Documents/",
+		},
+		{
+			name:           "tilde no expansion stays literal",
+			typed:          "~/Doc",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    false,
+			wantFullClean:  "/work/~/Doc",
+			wantParent:     "/work/~/",
+			wantBase:       "Doc",
+			wantUserPrefix: "~/",
+		},
+		{
+			name:           "tilde with empty home stays literal",
+			typed:          "~/Doc",
+			cwd:            cwd,
+			home:           "",
+			expandTilde:    true,
+			wantFullClean:  "/work/~/Doc",
+			wantParent:     "/work/~/",
+			wantBase:       "Doc",
+			wantUserPrefix: "~/",
+		},
+		{
+			name:           "tilde user form treated literally",
+			typed:          "~root/Doc",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/work/~root/Doc",
+			wantParent:     "/work/~root/",
+			wantBase:       "Doc",
+			wantUserPrefix: "~root/",
+		},
+		{
+			name:           "trailing separator after tilde",
+			typed:          "~/Documents/",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/Users/jane/Documents",
+			wantParent:     "/Users/jane/Documents/",
+			wantBase:       "",
+			wantUserPrefix: "~/Documents/",
+		},
+		{
+			name:           "dot-dot normalisation",
+			typed:          "~/a/../b",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/Users/jane/b",
+			wantParent:     "/Users/jane/",
+			wantBase:       "b",
+			wantUserPrefix: "~/a/../",
+		},
+		{
+			name:           "empty cwd keeps relative",
+			typed:          "Doc",
+			cwd:            "",
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "Doc",
+			wantParent:     "",
+			wantBase:       "Doc",
+			wantUserPrefix: "",
+		},
+		{
+			name:           "empty cwd with subpath",
+			typed:          "sub/Doc",
+			cwd:            "",
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "sub/Doc",
+			wantParent:     "sub/",
+			wantBase:       "Doc",
+			wantUserPrefix: "sub/",
+		},
+		{
+			name:           "root path",
+			typed:          "/",
+			cwd:            cwd,
+			home:           home,
+			expandTilde:    true,
+			wantFullClean:  "/",
+			wantParent:     "/",
+			wantBase:       "",
+			wantUserPrefix: "/",
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			fullClean, parent, base, userPrefix := resolvePath(c.typed, c.cwd, c.home, c.expandTilde)
+			if fullClean != c.wantFullClean {
+				t.Errorf("fullClean = %q, want %q", fullClean, c.wantFullClean)
+			}
+			if parent != c.wantParent {
+				t.Errorf("parent = %q, want %q", parent, c.wantParent)
+			}
+			if base != c.wantBase {
+				t.Errorf("base = %q, want %q", base, c.wantBase)
+			}
+			if userPrefix != c.wantUserPrefix {
+				t.Errorf("userPrefix = %q, want %q", userPrefix, c.wantUserPrefix)
+			}
+		})
+	}
+}
+
+// TestResolvePath_ParentBaseInvariant asserts that parent and base together
+// reconstruct fullClean modulo trailing-separator handling. The classifier
+// and candidate generator both rely on parent+base being a faithful split.
+func TestResolvePath_ParentBaseInvariant(t *testing.T) {
+	const (
+		cwd  = "/work"
+		home = "/Users/jane"
+	)
+	inputs := []string{
+		"Doc", "sub/Doc", "/abs/path/file.txt", "/abs/path/",
+		"~", "~/", "~/Doc", "~/Documents/report.md", "~/a/../b", "/",
+	}
+	for _, in := range inputs {
+		t.Run(in, func(t *testing.T) {
+			fullClean, parent, base, _ := resolvePath(in, cwd, home, true)
+			if fullClean == "" {
+				return
+			}
+			// parent may end with a separator; base may be empty.
+			joined := filepath.Clean(filepath.Join(parent, base))
+			if joined != fullClean {
+				t.Errorf("Join(parent=%q, base=%q) = %q, want %q",
+					parent, base, joined, fullClean)
+			}
+		})
+	}
+}
+
+// TestResolvePath_UserPrefixPreservesStyle confirms userPrefix is taken
+// verbatim from the typed string (post bare-tilde fixup), not from the
+// expanded path. Important for Tab-accept insertion strings.
+func TestResolvePath_UserPrefixPreservesStyle(t *testing.T) {
+	const home = "/Users/jane"
+	_, _, _, prefix := resolvePath("~/Documents/report.md", "/work", home, true)
+	if !strings.HasPrefix(prefix, "~/") {
+		t.Errorf("userPrefix = %q; expected to start with %q (preserve user's tilde style)", prefix, "~/")
+	}
+}

--- a/render.go
+++ b/render.go
@@ -32,17 +32,20 @@ func (m Model) Render() string {
 
 // renderedInput returns m.input.View() with the path-validity overlay
 // applied when m.pathState is active. The overlay is skipped when:
-//   - the user is cycling completions (pathState is frozen and its byte
-//     offsets refer to the pre-cycling input; styling against the cycled
-//     preview value would mis-style or panic)
 //   - the rendered input width exceeds m.width (textinput's internal
 //     scroll window obscures cell offsets and we'd paint garbage)
 //   - the stored offsets are out of range for the current value
 //     (defensive — shouldn't fire under correct lifecycle but cheap to
 //     check)
+//
+// During Tab cycling the overlay does apply: keyTab refreshes pathState
+// after every multi-match SetValue so the offsets and validity match the
+// cycled preview value. Cycling between candidates of different validity
+// (e.g. a valid file vs a directory under FileArgument) therefore shows
+// different colours per Tab.
 func (m Model) renderedInput() string {
 	base := m.input.View()
-	if !m.pathState.active || m.completionHolder != "" {
+	if !m.pathState.active {
 		return base
 	}
 	if m.pathState.valueStart >= m.pathState.valueEnd {

--- a/render.go
+++ b/render.go
@@ -23,11 +23,57 @@ func (m Model) View() tea.View {
 func (m Model) Render() string {
 	var output string
 	if m.historyIndex != -1 {
-		output = m.input.View()
+		output = m.renderedInput()
 	} else {
 		output = m.showCompletionsRender()
 	}
 	return lg.Width(m.width).Render(output)
+}
+
+// renderedInput returns m.input.View() with the path-validity overlay
+// applied when m.pathState is active. The overlay is skipped when:
+//   - the user is cycling completions (pathState is frozen and its byte
+//     offsets refer to the pre-cycling input; styling against the cycled
+//     preview value would mis-style or panic)
+//   - the rendered input width exceeds m.width (textinput's internal
+//     scroll window obscures cell offsets and we'd paint garbage)
+//   - the stored offsets are out of range for the current value
+//     (defensive — shouldn't fire under correct lifecycle but cheap to
+//     check)
+func (m Model) renderedInput() string {
+	base := m.input.View()
+	if !m.pathState.active || m.completionHolder != "" {
+		return base
+	}
+	if m.pathState.valueStart >= m.pathState.valueEnd {
+		return base
+	}
+	value := m.input.Value()
+	if m.pathState.valueEnd > len(value) {
+		return base
+	}
+	promptCells := lipgloss.Width(m.input.Prompt)
+	if promptCells+lipgloss.Width(value) > m.width {
+		return base
+	}
+	beforeCells := lipgloss.Width(value[:m.pathState.valueStart])
+	tokenCells := lipgloss.Width(value[m.pathState.valueStart:m.pathState.valueEnd])
+	if tokenCells == 0 {
+		return base
+	}
+
+	var style lipgloss.Style
+	switch m.pathState.validity {
+	case pathValid:
+		style = m.styles.Input.PathValid
+	case pathPartial:
+		style = m.styles.Input.PathPartial
+	default:
+		style = m.styles.Input.PathInvalid
+	}
+	rangeStart := promptCells + beforeCells
+	rangeEnd := rangeStart + tokenCells
+	return lipgloss.StyleRanges(base, lipgloss.NewRange(rangeStart, rangeEnd, style))
 }
 
 // MARK: completion Row Model
@@ -54,6 +100,11 @@ func kindOf(c completion) completionKind {
 		return argumentKind
 	case *Flag, Flag:
 		return flagKind
+	case pathCompletion, *pathCompletion:
+		// Path candidates are filesystem entries surfaced for an argument
+		// value — map to argumentKind so ShowIcons uses ArgumentIcon, not
+		// the fallback CommandIcon.
+		return argumentKind
 	}
 	return commandKind
 }
@@ -146,7 +197,7 @@ func visibleWindow(selected, total, rows int) (start, end int) {
 
 func (m Model) showCompletionsRender() string {
 	if len(m.completions) == 0 || (len(m.input.Value()) == 0 && !m.showAll) {
-		return m.input.View()
+		return m.renderedInput()
 	}
 
 	rows := m.completionRows()
@@ -176,9 +227,9 @@ func (m Model) showCompletionsRender() string {
 	renderedBox := style.Margin(0, 0, 0, offset).Render(box)
 
 	if m.CompletionsPosition == PositionAbove {
-		return renderedBox + "\n" + m.input.View()
+		return renderedBox + "\n" + m.renderedInput()
 	}
-	return m.input.View() + "\n" + renderedBox
+	return m.renderedInput() + "\n" + renderedBox
 }
 
 func (m Model) renderCompletionRow(row completionRow, titleWidth, completionsWidth int, selected, alt bool) string {

--- a/styles.go
+++ b/styles.go
@@ -17,14 +17,30 @@ var (
 	borderColor          = compat.AdaptiveColor{Light: lipgloss.Color("#CCD0DA"), Dark: lipgloss.Color("#313244")}
 	scrollIndicatorColor = compat.AdaptiveColor{Light: lipgloss.Color("#9CA0B0"), Dark: lipgloss.Color("#45475A")}
 	validColor           = compat.AdaptiveColor{Light: lipgloss.Color("#40A02B"), Dark: lipgloss.Color("#A6E3A1")}
+	invalidPathColor     = compat.AdaptiveColor{Light: lipgloss.Color("#D20F39"), Dark: lipgloss.Color("#F38BA8")}
 )
 
 var lg = lipgloss.NewStyle()
 
 // InputStyles styles the text inside the input field based on validation state.
+//
+// Valid and Invalid apply to the whole input value. PathValid, PathPartial,
+// and PathInvalid apply as a range overlay on the typed value of a
+// FileArgument / DirArgument / FileDirArgument when WithFilesystemCompletions
+// is enabled. Zero-value styles produce no overlay; hosts wanting defaults
+// should start from DefaultStyles and modify.
 type InputStyles struct {
 	Valid   lipgloss.Style
 	Invalid lipgloss.Style
+	// PathValid styles the typed value when it resolves to an entry of the
+	// expected kind.
+	PathValid lipgloss.Style
+	// PathPartial styles the typed value when it is a strict prefix of one
+	// or more existing entries (mid-navigation).
+	PathPartial lipgloss.Style
+	// PathInvalid styles the typed value when it cannot resolve or has the
+	// wrong kind.
+	PathInvalid lipgloss.Style
 }
 
 // CompletionStyles styles the completion list rows, border, match highlight, descriptions and icons.
@@ -55,8 +71,11 @@ type Styles struct {
 func DefaultStyles() Styles {
 	return Styles{
 		Input: InputStyles{
-			Valid:   lg.Foreground(validColor),
-			Invalid: lg.Foreground(mutedTextColor),
+			Valid:       lg.Foreground(validColor),
+			Invalid:     lg.Foreground(mutedTextColor),
+			PathValid:   lg.Foreground(validColor),
+			PathPartial: lg.Underline(true),
+			PathInvalid: lg.Foreground(invalidPathColor),
 		},
 		Completion: CompletionStyles{
 			Match:       lg.Bold(true).Foreground(accentColor),

--- a/update_test.go
+++ b/update_test.go
@@ -229,7 +229,10 @@ func TestMultipleTabsThenEnter(t *testing.T) {
 func TestRightArrow_AcceptsTabCompletion(t *testing.T) {
 	m := newTestModel(t)
 
-	m = simulateTyping(t, m, "git stash a")
+	// "git c" matches multiple subcommands (commit, clone, checkout) so
+	// Tab enters cycling state. A single-match Tab would auto-accept and
+	// defeat the cycling assertions below.
+	m = simulateTyping(t, m, "git c")
 	m = simulateKey(t, m, tea.KeyTab)
 
 	if m.completionIndex < 0 {
@@ -257,9 +260,10 @@ func TestRightArrow_AcceptsTabCompletion(t *testing.T) {
 func TestCtrlE_RoutesToKeyRight(t *testing.T) {
 	// Verify ctrl+e is routed to the same handler as right arrow by checking
 	// that it clears the completion holder when a completion is selected.
+	// Multi-match input ensures cycling state is active after Tab.
 	m := newTestModel(t)
 
-	m = simulateTyping(t, m, "git stash a")
+	m = simulateTyping(t, m, "git c")
 	m = simulateKey(t, m, tea.KeyTab)
 
 	if m.completionHolder == "" {
@@ -297,8 +301,9 @@ func TestRightArrow_AfterCloseCompletions_NoOp(t *testing.T) {
 	// Tab to select a completion, then close the completion list.
 	// Right arrow afterwards should not resurrect any accept behavior;
 	// state stays at whatever CloseCompletions restored.
+	// Multi-match input ensures cycling state is active after Tab.
 	m := newTestModel(t)
-	m = simulateTyping(t, m, "git stash a")
+	m = simulateTyping(t, m, "git c")
 	m = simulateKey(t, m, tea.KeyTab)
 	if m.completionIndex < 0 {
 		t.Fatal("expected a selected completion after tab")
@@ -387,7 +392,8 @@ func TestEnter_PartialSubcommand_ReturnsError(t *testing.T) {
 func TestBackspace_ResetsCompletionState(t *testing.T) {
 	m := newTestModel(t)
 
-	m = simulateTyping(t, m, "git stash a")
+	// Multi-match input ensures cycling state is active after Tab.
+	m = simulateTyping(t, m, "git c")
 	m = simulateKey(t, m, tea.KeyTab)
 
 	if m.completionIndex < 0 {
@@ -407,7 +413,8 @@ func TestBackspace_ResetsCompletionState(t *testing.T) {
 func TestTypingAfterTab_ResetsCompletionState(t *testing.T) {
 	m := newTestModel(t)
 
-	m = simulateTyping(t, m, "git stash a")
+	// Multi-match input ensures cycling state is active after Tab.
+	m = simulateTyping(t, m, "git c")
 	m = simulateKey(t, m, tea.KeyTab)
 
 	if m.completionIndex < 0 {

--- a/validation.go
+++ b/validation.go
@@ -373,7 +373,24 @@ func validateFileDirArgument(arg argument, value string) error {
 }
 
 func validatePath(arg argument, value string, wantFile, wantDir bool) error {
-	value = removeQuotes(value)
+	// File/dir args validate quotes the same way string args do — unclosed
+	// quotes are surfaced as UnclosedQuote rather than producing a misleading
+	// "path not found" against the literal quoted string.
+	if err := checkUnclosedQuote(arg, value, "\""); err != nil {
+		return err
+	}
+	if err := checkUnclosedQuote(arg, value, "'"); err != nil {
+		return err
+	}
+
+	unquoted, opener := stripQuotes(value)
+	// Tilde expands outside quotes and inside "..." but not inside '...'.
+	// See [resolvePath].
+	expandTilde := opener != '\''
+
+	cwd, _ := os.Getwd()
+	home, _ := os.UserHomeDir()
+	fullClean, _, _, _ := resolvePath(unquoted, cwd, home, expandTilde)
 
 	var pathType string
 	switch {
@@ -385,7 +402,7 @@ func validatePath(arg argument, value string, wantFile, wantDir bool) error {
 		pathType = "directory"
 	}
 
-	info, err := os.Stat(value)
+	info, err := os.Stat(fullClean)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return errPathNotExist(pathType, arg.getName())
@@ -399,13 +416,4 @@ func validatePath(arg argument, value string, wantFile, wantDir bool) error {
 		return errPathIsFile(arg.getName())
 	}
 	return nil
-}
-
-func removeQuotes(s string) string {
-	if len(s) >= 2 {
-		if (s[0] == '"' && s[len(s)-1] == '"') || (s[0] == '\'' && s[len(s)-1] == '\'') {
-			s = s[1 : len(s)-1]
-		}
-	}
-	return s
 }

--- a/validation_test.go
+++ b/validation_test.go
@@ -2,45 +2,10 @@ package bubblecomplete
 
 import (
 	"errors"
+	"os"
+	"path/filepath"
 	"testing"
 )
-
-func TestRemoveQuotes(t *testing.T) {
-	input := "\"This is a test\""
-	expected := "This is a test"
-	result := removeQuotes(input)
-	if result != expected {
-		t.Errorf("removeQuotes(%q) == %q, expected %q", input, result, expected)
-	}
-
-	input = "'This is a test'"
-	expected = "This is a test"
-	result = removeQuotes(input)
-	if result != expected {
-		t.Errorf("removeQuotes(%q) == %q, expected %q", input, result, expected)
-	}
-
-	input = "\"This is a test"
-	expected = "\"This is a test"
-	result = removeQuotes(input)
-	if result != expected {
-		t.Errorf("removeQuotes(%q) == %q, expected %q", input, result, expected)
-	}
-
-	input = "'This is a test"
-	expected = "'This is a test"
-	result = removeQuotes(input)
-	if result != expected {
-		t.Errorf("removeQuotes(%q) == %q, expected %q", input, result, expected)
-	}
-
-	input = "'This is a test='"
-	expected = "This is a test="
-	result = removeQuotes(input)
-	if result != expected {
-		t.Errorf("removeQuotes(%q) == %q, expected %q", input, result, expected)
-	}
-}
 
 func TestValidateCommandInput(t *testing.T) {
 	testCases := []struct {
@@ -464,5 +429,78 @@ func TestValidationError_UnwrapPreservesUnderlying(t *testing.T) {
 	}
 	if ve.Err == nil {
 		t.Fatal("expected non-nil underlying error for strconv failure")
+	}
+}
+
+func TestValidatePath_TildeExpansion(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	fpath := filepath.Join(home, "test_file.txt")
+	if err := os.WriteFile(fpath, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	arg := &PositionalArgument{Name: "F", Type: FileArgument, Required: true}
+
+	// ~/test_file.txt resolves against $HOME → real file → no error.
+	if err := validatePath(arg, "~/test_file.txt", true, false); err != nil {
+		t.Errorf("validatePath(%q): %v, want nil", "~/test_file.txt", err)
+	}
+
+	// ~/nonexistent → PathNotFound.
+	var ve *ValidationError
+	err := validatePath(arg, "~/nonexistent", true, false)
+	if !errors.As(err, &ve) || ve.Kind != PathNotFound {
+		t.Errorf("validatePath(%q): got %v, want PathNotFound", "~/nonexistent", err)
+	}
+
+	// Bare ~ under FileArgument → IsDir error (home itself is a directory).
+	err = validatePath(arg, "~", true, false)
+	if !errors.As(err, &ve) || ve.Kind != InvalidArgumentValue {
+		t.Errorf("validatePath(%q) FileArg: got %v, want InvalidArgumentValue (is-dir)", "~", err)
+	}
+
+	// Bare ~ under DirArgument → valid (home is a real directory).
+	dirArg := &PositionalArgument{Name: "D", Type: DirArgument, Required: true}
+	if err := validatePath(dirArg, "~", false, true); err != nil {
+		t.Errorf("validatePath(%q) DirArg: %v, want nil", "~", err)
+	}
+}
+
+func TestValidatePath_QuoteSemantics(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	fpath := filepath.Join(home, "quoted.txt")
+	if err := os.WriteFile(fpath, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	arg := &PositionalArgument{Name: "F", Type: FileArgument, Required: true}
+	var ve *ValidationError
+
+	// Matched double quotes: tilde expands → real file → no error.
+	if err := validatePath(arg, "\"~/quoted.txt\"", true, false); err != nil {
+		t.Errorf("matched double quotes: %v, want nil", err)
+	}
+
+	// Matched single quotes: tilde does NOT expand → literal "~/quoted.txt"
+	// resolved against CWD → not found.
+	err := validatePath(arg, "'~/quoted.txt'", true, false)
+	if !errors.As(err, &ve) || ve.Kind != PathNotFound {
+		t.Errorf("matched single quotes: got %v, want PathNotFound", err)
+	}
+
+	// Unclosed double quote → UnclosedQuote (matches StringArgument behaviour).
+	err = validatePath(arg, "\"~/foo", true, false)
+	if !errors.As(err, &ve) || ve.Kind != UnclosedQuote {
+		t.Errorf("unclosed double: got %v, want UnclosedQuote", err)
+	}
+
+	// Unclosed single quote → UnclosedQuote.
+	err = validatePath(arg, "'~/foo", true, false)
+	if !errors.As(err, &ve) || ve.Kind != UnclosedQuote {
+		t.Errorf("unclosed single: got %v, want UnclosedQuote", err)
 	}
 }


### PR DESCRIPTION
This branch adds opt-in filesystem path completion for FileArgument, DirArgument, and FileDirArgument.

  ### Added

  - New opt-in filesystem completion support via WithFilesystemCompletions(true).
  - New filesystem completion options:
      - WithFilesystemCompletionLimit(n) controls the max displayed filesystem candidates.
      - WithHiddenFiles(true) surfaces dotfiles even when the typed prefix does not start with ..
  - Live path candidates while typing file/dir argument values.
  - Directory candidates appear with a trailing / and can be drilled into with repeated Tab.
  - File candidates append a trailing space to signal that the token is complete.
  - Equals-form flag values are supported, including --path=foo and PowerShell-style -Path=foo.
  - Quoted path values are supported, including auto-quoting filenames that contain spaces.
  - ~ expansion is supported outside quotes and inside double quotes; single quotes suppress expansion.
  - Per-token path validity styling:
      - valid path: green
      - partial path: underline
      - invalid path: red
  - New style fields:
      - Input.PathValid
      - Input.PathPartial
      - Input.PathInvalid
  - Directory read caching with a small TTL/LRU cache to avoid repeated filesystem reads while typing.
  - Symlink-aware completion descriptions, such as symlink → file and symlink → dir.
  - README, example app, fuzz targets, and changelog coverage for the new filesystem behavior.

  ### Changed

  - Filesystem argument validation now uses the shared path resolver:
      - ~/... is resolved against the user’s home directory.
      - relative paths resolve from the process working directory.
      - unclosed quotes now return UnclosedQuote instead of a misleading path-not-found error.
  - Tab behavior now auto-accepts a single completion candidate, enabling shell-style path drill-down.
  - Path completion state is refreshed while cycling directory candidates so validity styling tracks the visible candidate.

  ### Notes / Limitations

  - Filesystem completion is off by default.
  - Permission-denied directories silently fall back to normal argument hints.
  - Devices, sockets, and pipes are not shown as candidates, though typed paths still validate according to the existing path rules.
  - Filenames containing literal quote characters are inserted verbatim and may not re-parse as a single token.
  - Multi-token unquoted paths are not recovered after a space is typed.
  - Very large cold directories may still cause a one-time stall on first read.
  - Case sensitivity is a platform heuristic: Linux is treated as case-sensitive, macOS/Windows as case-insensitive.
  - The path overlay is skipped when input is wider than the terminal.